### PR TITLE
ci: add auto-merge workflow for dependency PRs

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -24,4 +24,5 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --rebase "$PR_URL"
+        # --auto waits for required status checks before merging
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically approves and enables auto-merge for PRs from Renovate and Dependabot bots.