### PR TITLE
ci: add merge_group trigger to workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [published]
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "38 4 * * 0"
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  merge_group:
   schedule:
     # Run quality checks weekly on Sundays at 02:00 UTC
     - cron: "0 2 * * 0"


### PR DESCRIPTION
## Summary
Enable GitHub merge queue functionality by adding `merge_group` event trigger to all CI workflows.

## Changes
- `check.yml`: Added `merge_group:` trigger
- `quality.yml`: Added `merge_group:` trigger  
- `docker.yml`: Added `merge_group:` trigger

## Why
The merge queue requires workflows to run on the `merge_group` event. Without this trigger, PRs added to the merge queue get stuck in "AWAITING_CHECKS" state since the required checks never run.

This fixes the merge queue issue blocking PR #348 (security fix for gofiber/utils/v2).

## Test plan
- [ ] CI passes
- [ ] Merge queue successfully processes PRs after merge