### PR TITLE
fix(ci): use merge queue API for auto-merge

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           gh api graphql -f query='
             mutation($pullRequestId: ID!) {
-              enqueuePullRequest(input: {pullRequestId: $pullRequestId}) {
+              enqueuePullRequest(input: {pullRequestId: $pullRequestId, mergeMethod: SQUASH}) {
                 mergeQueueEntry { id }
               }
-            }' -f pullRequestId="$PR_NODE_ID"
+            }' -f pullRequestId="$PR_NODE_ID" || { echo "Failed to enqueue PR in merge queue"; exit 1; }


### PR DESCRIPTION
## Summary

Fixes auto-merge for dependency PRs when merge queue is enabled.

**Problem:** `gh pr merge --auto` silently fails when merge queue is enabled, outputting only:
```
! The merge strategy for main is set by the merge queue
```

**Solution:** Use GraphQL `enqueuePullRequest` mutation to properly add PRs to the merge queue instead of using `--auto` flag.

## Test Plan

- [ ] CI passes
- [ ] Next Renovate PR should be automatically added to merge queue after approval