### PR TITLE
fix(ci): remove invalid mergeMethod argument

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           gh api graphql -f query='
             mutation($pullRequestId: ID!) {
-              enqueuePullRequest(input: {pullRequestId: $pullRequestId, mergeMethod: SQUASH}) {
+              enqueuePullRequest(input: {pullRequestId: $pullRequestId}) {
                 mergeQueueEntry { id }
               }
             }' -f pullRequestId="$PR_NODE_ID" || { echo "Failed to enqueue PR in merge queue"; exit 1; }


### PR DESCRIPTION
The `mergeMethod` argument is not valid for `enqueuePullRequest` mutation. Merge method is determined by merge queue configuration.