### PR TITLE
fix(ci): avoid circular dependency in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -40,13 +40,33 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Waiting for all required status checks to pass..."
-          # Wait up to 30 minutes for checks to complete
-          timeout 1800 gh pr checks "$PR_URL" --watch --fail-fast || {
-            echo "Status checks did not pass within timeout"
-            exit 1
-          }
-          echo "All status checks passed!"
+          echo "Waiting for all status checks to pass..."
+          # Poll checks every 10s for up to 30 minutes, excluding self to avoid circular dependency
+          for i in {1..180}; do
+            # Get check states, excluding this workflow
+            CHECKS=$(gh pr checks "$PR_URL" --json name,state \
+              --jq '[.[] | select(.name != "Auto-merge dependency PRs")]')
+
+            FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
+            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')
+
+            if [ "$FAILED" != "0" ]; then
+              echo "Some checks failed:"
+              echo "$CHECKS" | jq -r '.[] | select(.state == "FAILURE" or .state == "ERROR") | "  - \(.name): \(.state)"'
+              exit 1
+            fi
+
+            if [ "$PENDING" = "0" ]; then
+              echo "All status checks passed!"
+              exit 0
+            fi
+
+            echo "Waiting for $PENDING check(s) to complete... (attempt $i/180)"
+            sleep 10
+          done
+
+          echo "Timeout waiting for checks to complete"
+          exit 1
 
       - name: Add to merge queue
         env:


### PR DESCRIPTION
## Summary
- The auto-merge workflow was watching itself via `gh pr checks --watch`, causing a 30-minute timeout and failing
- Now polls checks every 10s while excluding "Auto-merge dependency PRs" from the watched set
- Fixes issue where PR #363 (and other dependabot/renovate PRs) couldn't auto-merge

## Test plan
- [ ] Merge this PR
- [ ] Verify PR #363 auto-merge workflow succeeds