### PR TITLE
feat: use logged-in user credentials for all LDAP operations

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -18,12 +18,28 @@ These settings must be configured for LDAP Manager to function:
 
 ### LDAP Connection Settings
 
-| Setting           | Environment Variable     | CLI Flag              | Description                            | Example                       |
-| ----------------- | ------------------------ | --------------------- | -------------------------------------- | ----------------------------- |
-| LDAP Server       | `LDAP_SERVER`            | `--ldap-server`       | LDAP server URI with protocol and port | `ldaps://dc1.example.com:636` |
-| Base DN           | `LDAP_BASE_DN`           | `--base-dn`           | Base Distinguished Name for searches   | `DC=example,DC=com`           |
-| Readonly User     | `LDAP_READONLY_USER`     | `--readonly-user`     | Service account username               | `readonly`                    |
-| Readonly Password | `LDAP_READONLY_PASSWORD` | `--readonly-password` | Service account password               | `secure_password123`          |
+| Setting           | Environment Variable     | CLI Flag              | Description                            | Example                       | Required |
+| ----------------- | ------------------------ | --------------------- | -------------------------------------- | ----------------------------- | -------- |
+| LDAP Server       | `LDAP_SERVER`            | `--ldap-server`       | LDAP server URI with protocol and port | `ldaps://dc1.example.com:636` | Yes      |
+| Base DN           | `LDAP_BASE_DN`           | `--base-dn`           | Base Distinguished Name for searches   | `DC=example,DC=com`           | Yes      |
+| Readonly User     | `LDAP_READONLY_USER`     | `--readonly-user`     | Service account username               | `readonly`                    | No       |
+| Readonly Password | `LDAP_READONLY_PASSWORD` | `--readonly-password` | Service account password               | `secure_password123`          | No       |
+
+### Operating Modes
+
+LDAP Manager supports two operating modes based on whether a service account is configured:
+
+**Service Account Mode** (both `LDAP_READONLY_USER` and `LDAP_READONLY_PASSWORD` set):
+- Background cache refreshes LDAP data every 30 seconds
+- Health checks verify LDAP connectivity
+- Service account used for initial user lookup during authentication
+
+**Per-User Credentials Mode** (no service account configured):
+- Each request uses the logged-in user's own LDAP credentials
+- No background cache (data fetched fresh per request)
+- Health checks report simplified status
+- Requires Active Directory with UPN-based authentication (`user@domain`)
+- Users must have sufficient LDAP permissions to read directory data
 
 ### LDAP Server URI Format
 
@@ -169,6 +185,24 @@ LDAP_IS_AD=true
 LOG_LEVEL=warn
 PERSIST_SESSIONS=true
 SESSION_PATH=/data/sessions.bbolt
+SESSION_DURATION=30m
+```
+
+### Per-User Credentials (No Service Account)
+
+For Active Directory environments where each user authenticates with their own credentials:
+
+```bash
+# .env.local
+LDAP_SERVER=ldaps://dc1.ad.example.com:636
+LDAP_BASE_DN=DC=ad,DC=example,DC=com
+LDAP_IS_AD=true
+
+# No LDAP_READONLY_USER or LDAP_READONLY_PASSWORD
+# Users authenticate with their own AD credentials via UPN (user@domain)
+
+LOG_LEVEL=info
+PERSIST_SESSIONS=true
 SESSION_DURATION=30m
 ```
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -30,11 +30,13 @@ These settings must be configured for LDAP Manager to function:
 LDAP Manager supports two operating modes based on whether a service account is configured:
 
 **Service Account Mode** (both `LDAP_READONLY_USER` and `LDAP_READONLY_PASSWORD` set):
+
 - Background cache refreshes LDAP data every 30 seconds
 - Health checks verify LDAP connectivity
 - Service account used for initial user lookup during authentication
 
 **Per-User Credentials Mode** (no service account configured):
+
 - Each request uses the logged-in user's own LDAP credentials
 - No background cache (data fetched fresh per request)
 - Health checks report simplified status

--- a/internal/ldap_cache/cache.go
+++ b/internal/ldap_cache/cache.go
@@ -129,13 +129,16 @@ func (c *Cache[T]) update(fn func(*T)) {
 	c.buildIndexes()
 }
 
-// Get returns a copy of all cached items.
-// This operation is read-locked to allow concurrent access from multiple readers.
+// Get returns a snapshot copy of all cached items.
+// The returned slice is safe to iterate without holding any lock.
 func (c *Cache[T]) Get() []T {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	return c.items
+	result := make([]T, len(c.items))
+	copy(result, c.items)
+
+	return result
 }
 
 // Find searches the cache for the first item matching the provided predicate.

--- a/internal/ldap_cache/manager.go
+++ b/internal/ldap_cache/manager.go
@@ -540,6 +540,95 @@ func (m *Manager) OnRemoveUserFromGroup(userDN, groupDN string) {
 	})
 }
 
+// PopulateGroupsForUserFromData creates a FullLDAPUser with populated group memberships
+// using provided data instead of cache. Works identically to PopulateGroupsForUser
+// but operates on explicit slices rather than the cache.
+func PopulateGroupsForUserFromData(user *ldap.User, allGroups []ldap.Group) *FullLDAPUser {
+	full := &FullLDAPUser{
+		User:   *user,
+		Groups: make([]ldap.Group, 0),
+	}
+
+	userDN := user.DN()
+
+	for _, group := range allGroups {
+		for _, memberDN := range group.Members {
+			if memberDN == userDN {
+				full.Groups = append(full.Groups, group)
+
+				break
+			}
+		}
+	}
+
+	return full
+}
+
+// PopulateUsersForGroupFromData creates a FullLDAPGroup with populated member list
+// using provided data instead of cache. Works identically to PopulateUsersForGroup
+// but operates on explicit slices rather than the cache.
+func PopulateUsersForGroupFromData(group *ldap.Group, allUsers []ldap.User, allGroups []ldap.Group, showDisabled bool) *FullLDAPGroup {
+	full := &FullLDAPGroup{
+		Group:        *group,
+		Members:      make([]ldap.User, 0),
+		ParentGroups: make([]ldap.Group, 0),
+	}
+
+	// Build a map for O(1) user lookups by DN
+	usersByDN := make(map[string]*ldap.User, len(allUsers))
+	for i := range allUsers {
+		usersByDN[allUsers[i].DN()] = &allUsers[i]
+	}
+
+	for _, memberDN := range group.Members {
+		if user, ok := usersByDN[memberDN]; ok {
+			if !showDisabled && !user.Enabled {
+				continue
+			}
+
+			full.Members = append(full.Members, *user)
+		}
+	}
+
+	// Build a map for O(1) group lookups by DN
+	groupsByDN := make(map[string]*ldap.Group, len(allGroups))
+	for i := range allGroups {
+		groupsByDN[allGroups[i].DN()] = &allGroups[i]
+	}
+
+	for _, parentDN := range group.MemberOf {
+		if parentGroup, ok := groupsByDN[parentDN]; ok {
+			full.ParentGroups = append(full.ParentGroups, *parentGroup)
+		}
+	}
+
+	return full
+}
+
+// PopulateGroupsForComputerFromData creates a FullLDAPComputer with populated group memberships
+// using provided data instead of cache. Works identically to PopulateGroupsForComputer
+// but operates on explicit slices rather than the cache.
+func PopulateGroupsForComputerFromData(computer *ldap.Computer, allGroups []ldap.Group) *FullLDAPComputer {
+	full := &FullLDAPComputer{
+		Computer: *computer,
+		Groups:   make([]ldap.Group, 0),
+	}
+
+	computerDN := computer.DN()
+
+	for _, group := range allGroups {
+		for _, memberDN := range group.Members {
+			if memberDN == computerDN {
+				full.Groups = append(full.Groups, group)
+
+				break
+			}
+		}
+	}
+
+	return full
+}
+
 // GetMetrics returns the current cache metrics for monitoring and observability.
 // Provides comprehensive statistics about cache performance, health, and operations.
 func (m *Manager) GetMetrics() *Metrics {

--- a/internal/ldap_cache/manager.go
+++ b/internal/ldap_cache/manager.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	ldap "github.com/netresearch/simple-ldap-go"
@@ -40,9 +41,9 @@ type Manager struct {
 
 	client          LDAPClient    // LDAP client for directory operations
 	metrics         *Metrics      // Performance metrics and health monitoring
-	refreshInterval time.Duration // Configurable refresh interval (default 30s)
-	warmupComplete  bool          // Tracks if initial cache warming is complete
-	retryConfig     retry.Config  // Retry configuration for LDAP operations
+	refreshInterval time.Duration  // Configurable refresh interval (default 30s)
+	warmupComplete  atomic.Bool    // Tracks if initial cache warming is complete (concurrent-safe)
+	retryConfig     retry.Config   // Retry configuration for LDAP operations
 
 	Users     Cache[ldap.User]     // Cached user entries with O(1) indexed lookups
 	Groups    Cache[ldap.Group]    // Cached group entries with O(1) indexed lookups
@@ -95,7 +96,6 @@ func NewWithConfig(client LDAPClient, refreshInterval time.Duration) *Manager {
 		client:          client,
 		metrics:         metrics,
 		refreshInterval: refreshInterval,
-		warmupComplete:  false,
 		retryConfig:     retry.LDAPConfig(),
 		Users:           NewCachedWithMetrics[ldap.User](metrics),
 		Groups:          NewCachedWithMetrics[ldap.Group](metrics),
@@ -209,7 +209,7 @@ func (m *Manager) WarmupCache() {
 	duration := time.Since(startTime)
 
 	if !hasErrors {
-		m.warmupComplete = true
+		m.warmupComplete.Store(true)
 		m.metrics.RecordRefreshComplete(startTime, m.Users.Count(), m.Groups.Count(), m.Computers.Count())
 		log.Info().
 			Int("total_entities", totalEntities).
@@ -226,7 +226,7 @@ func (m *Manager) WarmupCache() {
 // IsWarmedUp returns true if the initial cache warming process has completed successfully.
 // Used to determine if the cache is ready to serve requests optimally.
 func (m *Manager) IsWarmedUp() bool {
-	return m.warmupComplete
+	return m.warmupComplete.Load()
 }
 
 // RefreshUsers fetches all users from LDAP and updates the user cache.

--- a/internal/ldap_cache/manager.go
+++ b/internal/ldap_cache/manager.go
@@ -414,22 +414,7 @@ func (m *Manager) FindComputerBySAMAccountName(samAccountName string) (*ldap.Com
 // which works correctly even when OpenLDAP's memberOf overlay is not enabled.
 // Returns a complete user object with expanded group information.
 func (m *Manager) PopulateGroupsForUser(user *ldap.User) *FullLDAPUser {
-	full := &FullLDAPUser{
-		User:   *user,
-		Groups: make([]ldap.Group, 0),
-	}
-
-	userDN := user.DN()
-
-	// Iterate through all groups and check if user is a member
-	// This approach works regardless of whether memberOf overlay is enabled
-	for _, group := range m.Groups.Get() {
-		if slices.Contains(group.Members, userDN) {
-			full.Groups = append(full.Groups, group)
-		}
-	}
-
-	return full
+	return PopulateGroupsForUserFromData(user, m.Groups.Get())
 }
 
 // PopulateUsersForGroup creates a FullLDAPGroup with populated member list.
@@ -438,32 +423,7 @@ func (m *Manager) PopulateGroupsForUser(user *ldap.User) *FullLDAPUser {
 // When showDisabled is false, filters out disabled users from membership.
 // Returns a complete group object with expanded member and parent group information.
 func (m *Manager) PopulateUsersForGroup(group *ldap.Group, showDisabled bool) *FullLDAPGroup {
-	full := &FullLDAPGroup{
-		Group:        *group,
-		Members:      make([]ldap.User, 0),
-		ParentGroups: make([]ldap.Group, 0),
-	}
-
-	for _, userDN := range group.Members {
-		user, err := m.FindUserByDN(userDN)
-		if err == nil {
-			if !showDisabled && !user.Enabled {
-				continue
-			}
-
-			full.Members = append(full.Members, *user)
-		}
-	}
-
-	// Resolve parent groups from MemberOf
-	for _, parentDN := range group.MemberOf {
-		parentGroup, err := m.FindGroupByDN(parentDN)
-		if err == nil {
-			full.ParentGroups = append(full.ParentGroups, *parentGroup)
-		}
-	}
-
-	return full
+	return PopulateUsersForGroupFromData(group, m.Users.Get(), m.Groups.Get(), showDisabled)
 }
 
 // PopulateGroupsForComputer creates a FullLDAPComputer with populated group memberships.
@@ -472,22 +432,7 @@ func (m *Manager) PopulateUsersForGroup(group *ldap.Group, showDisabled bool) *F
 // which works correctly even when OpenLDAP's memberOf overlay is not enabled.
 // Returns a complete computer object with expanded group information.
 func (m *Manager) PopulateGroupsForComputer(computer *ldap.Computer) *FullLDAPComputer {
-	full := &FullLDAPComputer{
-		Computer: *computer,
-		Groups:   make([]ldap.Group, 0),
-	}
-
-	computerDN := computer.DN()
-
-	// Iterate through all groups and check if computer is a member
-	// This approach works regardless of whether memberOf overlay is enabled
-	for _, group := range m.Groups.Get() {
-		if slices.Contains(group.Members, computerDN) {
-			full.Groups = append(full.Groups, group)
-		}
-	}
-
-	return full
+	return PopulateGroupsForComputerFromData(computer, m.Groups.Get())
 }
 
 // OnAddUserToGroup updates cache when a user is added to a group.
@@ -552,12 +497,8 @@ func PopulateGroupsForUserFromData(user *ldap.User, allGroups []ldap.Group) *Ful
 	userDN := user.DN()
 
 	for _, group := range allGroups {
-		for _, memberDN := range group.Members {
-			if memberDN == userDN {
-				full.Groups = append(full.Groups, group)
-
-				break
-			}
+		if slices.Contains(group.Members, userDN) {
+			full.Groups = append(full.Groups, group)
 		}
 	}
 
@@ -567,7 +508,9 @@ func PopulateGroupsForUserFromData(user *ldap.User, allGroups []ldap.Group) *Ful
 // PopulateUsersForGroupFromData creates a FullLDAPGroup with populated member list
 // using provided data instead of cache. Works identically to PopulateUsersForGroup
 // but operates on explicit slices rather than the cache.
-func PopulateUsersForGroupFromData(group *ldap.Group, allUsers []ldap.User, allGroups []ldap.Group, showDisabled bool) *FullLDAPGroup {
+func PopulateUsersForGroupFromData(
+	group *ldap.Group, allUsers []ldap.User, allGroups []ldap.Group, showDisabled bool,
+) *FullLDAPGroup {
 	full := &FullLDAPGroup{
 		Group:        *group,
 		Members:      make([]ldap.User, 0),
@@ -617,12 +560,8 @@ func PopulateGroupsForComputerFromData(computer *ldap.Computer, allGroups []ldap
 	computerDN := computer.DN()
 
 	for _, group := range allGroups {
-		for _, memberDN := range group.Members {
-			if memberDN == computerDN {
-				full.Groups = append(full.Groups, group)
-
-				break
-			}
+		if slices.Contains(group.Members, computerDN) {
+			full.Groups = append(full.Groups, group)
 		}
 	}
 

--- a/internal/options/app.go
+++ b/internal/options/app.go
@@ -264,12 +264,9 @@ func Parse() (*Opts, error) {
 	if err := validateRequired("base-dn", fBaseDN); err != nil {
 		return nil, err
 	}
-	if err := validateRequired("readonly-user", fReadonlyUser); err != nil {
-		return nil, err
-	}
-	if err := validateRequired("readonly-password", fReadonlyPassword); err != nil {
-		return nil, err
-	}
+	// readonly-user and readonly-password are optional.
+	// When not configured, the app uses per-user LDAP credentials
+	// and the background cache is disabled.
 
 	if *fPersistSessions {
 		if err := validateRequired("session-path", fSessionPath); err != nil {

--- a/internal/options/parse_test.go
+++ b/internal/options/parse_test.go
@@ -107,8 +107,7 @@ func TestParse_MissingRequiredFields(t *testing.T) {
 	}{
 		{"MissingLDAPServer", "LDAP_SERVER", "ldap-server"},
 		{"MissingBaseDN", "LDAP_BASE_DN", "base-dn"},
-		{"MissingReadonlyUser", "LDAP_READONLY_USER", "readonly-user"},
-		{"MissingReadonlyPassword", "LDAP_READONLY_PASSWORD", "readonly-password"},
+		// readonly-user and readonly-password are now optional
 	}
 
 	for _, tt := range tests {

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -3,7 +3,10 @@ package web
 // HTTP handlers and middleware for authentication and session management.
 
 import (
+	"strings"
+
 	"github.com/gofiber/fiber/v2"
+	ldap "github.com/netresearch/simple-ldap-go"
 	"github.com/rs/zerolog/log"
 
 	"github.com/netresearch/ldap-manager/internal/version"
@@ -33,15 +36,15 @@ func (a *App) loginHandler(c *fiber.Ctx) error {
 	password := c.FormValue("password")
 
 	if username != "" && password != "" {
-		user, err := a.ldapReadonly.CheckPasswordForSAMAccountName(username, password)
-		if err != nil {
+		user, authErr := a.authenticateUser(username, password)
+		if authErr != nil {
 			// Record failed attempt for rate limiting
 			ip := c.IP()
 			blocked := a.rateLimiter.RecordAttempt(ip)
 
 			// Log username for security audit trail - intentional per OWASP logging guidelines
 			log.Warn().
-				Err(err).
+				Err(authErr).
 				Str("username", username).
 				Str("ip", ip).
 				Int("remaining_attempts", a.rateLimiter.GetRemainingAttempts(ip)).
@@ -67,6 +70,8 @@ func (a *App) loginHandler(c *fiber.Ctx) error {
 		a.rateLimiter.ResetAttempts(c.IP())
 
 		sess.Set("dn", user.DN())
+		sess.Set("password", password)
+		sess.Set("username", username)
 		if err := sess.Save(); err != nil {
 			return handle500(c, err)
 		}
@@ -87,4 +92,56 @@ func (a *App) loginHandler(c *fiber.Ctx) error {
 		a.GetCSRFToken(c),
 		a.GetStylesPath(),
 	).Render(c.UserContext(), c.Response().BodyWriter())
+}
+
+// authenticateUser verifies credentials using either the service account
+// (when configured) or direct UPN bind (for AD without service account).
+func (a *App) authenticateUser(username, password string) (*ldap.User, error) {
+	if a.ldapReadonly != nil {
+		// Service account available: use it to look up user and verify password
+		return a.ldapReadonly.CheckPasswordForSAMAccountName(username, password)
+	}
+
+	// No service account: authenticate via UPN bind (Active Directory)
+	return a.authenticateViaUPNBind(username, password)
+}
+
+// authenticateViaUPNBind authenticates by binding as user@domain directly.
+// Used when no service account (readonly user) is configured.
+func (a *App) authenticateViaUPNBind(username, password string) (*ldap.User, error) {
+	domain := domainFromBaseDN(a.ldapConfig.BaseDN)
+	upn := username + "@" + domain
+
+	// Bind as the user via UPN
+	userClient, err := ldap.New(a.ldapConfig, upn, password, a.ldapOpts...)
+	if err != nil {
+		return nil, err
+	}
+	defer userClient.Close()
+
+	// Look up user details using the user's own connection
+	user, err := userClient.FindUserBySAMAccountName(username)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+// domainFromBaseDN derives a DNS domain from an LDAP BaseDN.
+// Example: "DC=example,DC=com" → "example.com"
+func domainFromBaseDN(baseDN string) string {
+	parts := strings.Split(baseDN, ",")
+	domains := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		upper := strings.ToUpper(part)
+
+		if strings.HasPrefix(upper, "DC=") {
+			domains = append(domains, part[3:])
+		}
+	}
+
+	return strings.Join(domains, ".")
 }

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -117,7 +117,7 @@ func (a *App) authenticateViaUPNBind(username, password string) (*ldap.User, err
 	if err != nil {
 		return nil, err
 	}
-	defer userClient.Close()
+	defer func() { _ = userClient.Close() }()
 
 	// Look up user details using the user's own connection
 	user, err := userClient.FindUserBySAMAccountName(username)

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -3,6 +3,7 @@ package web
 // HTTP handlers and middleware for authentication and session management.
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -52,8 +53,14 @@ func (a *App) loginHandler(c *fiber.Ctx) error {
 
 			// If blocked after this attempt, return rate limit error
 			if blocked {
-				return c.Status(fiber.StatusTooManyRequests).
-					SendString("Too many failed login attempts. Please try again later.")
+				c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
+
+				return templates.LoginWithStyles(
+					templates.Flashes(templates.ErrorFlash("Too many failed login attempts. Please try again later.")),
+					"",
+					a.GetCSRFToken(c),
+					a.GetStylesPath(),
+				).Render(c.UserContext(), c.Response().BodyWriter())
 			}
 
 			c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
@@ -69,7 +76,15 @@ func (a *App) loginHandler(c *fiber.Ctx) error {
 		// Successful login - reset rate limit counter
 		a.rateLimiter.ResetAttempts(c.IP())
 
+		// Regenerate session ID to prevent session fixation attacks
+		if err := sess.Regenerate(); err != nil {
+			return handle500(c, err)
+		}
+
 		sess.Set("dn", user.DN())
+		// Password stored in session for per-user LDAP binding.
+		// Mitigated by: session-only cookies (HttpOnly, SameSite=Strict),
+		// configurable session TTL, and server-side session storage.
 		sess.Set("password", password)
 		sess.Set("username", username)
 		if err := sess.Save(); err != nil {
@@ -107,22 +122,31 @@ func (a *App) authenticateUser(username, password string) (*ldap.User, error) {
 }
 
 // authenticateViaUPNBind authenticates by binding as user@domain directly.
-// Used when no service account (readonly user) is configured.
+// Used when no service account is configured.
 func (a *App) authenticateViaUPNBind(username, password string) (*ldap.User, error) {
+	// Validate username to prevent LDAP injection in UPN construction
+	if strings.ContainsAny(username, `\@,=+"<>#;`) {
+		return nil, fmt.Errorf("invalid characters in username")
+	}
+
 	domain := domainFromBaseDN(a.ldapConfig.BaseDN)
+	if domain == "" {
+		return nil, fmt.Errorf("cannot derive domain from BaseDN %q: no DC components found", a.ldapConfig.BaseDN)
+	}
+
 	upn := username + "@" + domain
 
 	// Bind as the user via UPN
 	userClient, err := ldap.New(a.ldapConfig, upn, password, a.ldapOpts...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("UPN bind failed: %w", err)
 	}
 	defer func() { _ = userClient.Close() }()
 
 	// Look up user details using the user's own connection
 	user, err := userClient.FindUserBySAMAccountName(username)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("user lookup after UPN bind: %w", err)
 	}
 
 	return user, nil

--- a/internal/web/computers.go
+++ b/internal/web/computers.go
@@ -7,24 +7,36 @@ import (
 	"sort"
 
 	"github.com/gofiber/fiber/v2"
+	ldap "github.com/netresearch/simple-ldap-go"
 
+	"github.com/netresearch/ldap-manager/internal/ldap_cache"
 	"github.com/netresearch/ldap-manager/internal/web/templates"
 )
 
-// computersHandler handles GET /computers requests to list all computer accounts in the LDAP directory.
-// Supports optional show-disabled query parameter to include disabled computer accounts.
-// Computers are sorted alphabetically by CN (Common Name) and returned as HTML using template caching.
-//
-// Query Parameters:
-//   - show-disabled: Set to "1" to include disabled computers in the listing
-//
-// Returns:
-//   - 200: HTML page with computer listing
-//   - 500: Internal server error if LDAP query fails
 func (a *App) computersHandler(c *fiber.Ctx) error {
-	// Authentication handled by middleware, no need to check session
 	showDisabled := c.Query("show-disabled", "0") == "1"
-	computers := a.ldapCache.FindComputers(showDisabled)
+
+	userLDAP, err := a.getUserLDAP(c)
+	if err != nil {
+		return handle500(c, err)
+	}
+	defer userLDAP.Close()
+
+	allComputers, err := userLDAP.FindComputers()
+	if err != nil {
+		return handle500(c, err)
+	}
+
+	computers := allComputers
+	if !showDisabled {
+		computers = nil
+		for _, comp := range allComputers {
+			if comp.Enabled {
+				computers = append(computers, comp)
+			}
+		}
+	}
+
 	sort.SliceStable(computers, func(i, j int) bool {
 		return computers[i].CN() < computers[j].CN()
 	})
@@ -33,42 +45,53 @@ func (a *App) computersHandler(c *fiber.Ctx) error {
 	return a.templateCache.RenderWithCache(c, templates.Computers(computers))
 }
 
-// computerHandler handles GET /computers/:computerDN requests to display detailed information for a specific computer.
-// The computerDN path parameter must be URL-encoded Distinguished Name of the computer account.
-// Returns computer details including attributes, group memberships, and system information.
-//
-// Path Parameters:
-//   - computerDN: URL-encoded Distinguished Name of the computer
-//     (e.g. "CN=WORKSTATION01,OU=Computers,DC=example,DC=com")
-//
-// Returns:
-//   - 200: HTML page with computer details and group memberships
-//   - 500: Internal server error if computer not found or LDAP query fails
-//
-// Example:
-//
-//	GET /computers/CN%3DWORKSTATION01%2COU%3DComputers%2CDC%3Dexample%2CDC%3Dcom
 func (a *App) computerHandler(c *fiber.Ctx) error {
-	// Authentication handled by middleware, no need to check session
 	computerDN, err := url.PathUnescape(c.Params("*"))
 	if err != nil {
 		return handle500(c, err)
 	}
 
-	thinComputer, err := a.ldapCache.FindComputerByDN(computerDN)
+	userLDAP, err := a.getUserLDAP(c)
+	if err != nil {
+		return handle500(c, err)
+	}
+	defer userLDAP.Close()
+
+	computers, err := userLDAP.FindComputers()
 	if err != nil {
 		return handle500(c, err)
 	}
 
-	computer := a.ldapCache.PopulateGroupsForComputer(thinComputer)
-	sort.SliceStable(computer.Groups, func(i, j int) bool {
-		return computer.Groups[i].CN() < computer.Groups[j].CN()
+	computer := findComputerByDN(computers, computerDN)
+	if computer == nil {
+		return handle500(c, ldap.ErrComputerNotFound)
+	}
+
+	groups, err := userLDAP.FindGroups()
+	if err != nil {
+		return handle500(c, err)
+	}
+
+	fullComputer := ldap_cache.PopulateGroupsForComputerFromData(computer, groups)
+	sort.SliceStable(fullComputer.Groups, func(i, j int) bool {
+		return fullComputer.Groups[i].CN() < fullComputer.Groups[j].CN()
 	})
 
 	// Use template caching with computer DN as additional cache data
 	return a.templateCache.RenderWithCache(
 		c,
-		templates.Computer(computer),
+		templates.Computer(fullComputer),
 		"computerDN:"+computerDN,
 	)
+}
+
+// findComputerByDN searches for a computer by DN in a slice.
+func findComputerByDN(computers []ldap.Computer, dn string) *ldap.Computer {
+	for i := range computers {
+		if computers[i].DN() == dn {
+			return &computers[i]
+		}
+	}
+
+	return nil
 }

--- a/internal/web/computers.go
+++ b/internal/web/computers.go
@@ -20,7 +20,7 @@ func (a *App) computersHandler(c *fiber.Ctx) error {
 	if err != nil {
 		return handle500(c, err)
 	}
-	defer userLDAP.Close()
+	defer func() { _ = userLDAP.Close() }()
 
 	allComputers, err := userLDAP.FindComputers()
 	if err != nil {
@@ -55,7 +55,7 @@ func (a *App) computerHandler(c *fiber.Ctx) error {
 	if err != nil {
 		return handle500(c, err)
 	}
-	defer userLDAP.Close()
+	defer func() { _ = userLDAP.Close() }()
 
 	computers, err := userLDAP.FindComputers()
 	if err != nil {

--- a/internal/web/computers.go
+++ b/internal/web/computers.go
@@ -64,7 +64,9 @@ func (a *App) computerHandler(c *fiber.Ctx) error {
 
 	computer := findComputerByDN(computers, computerDN)
 	if computer == nil {
-		return handle500(c, ldap.ErrComputerNotFound)
+		c.Status(fiber.StatusNotFound)
+
+		return a.fourOhFourHandler(c)
 	}
 
 	groups, err := userLDAP.FindGroups()

--- a/internal/web/groups.go
+++ b/internal/web/groups.go
@@ -12,8 +12,17 @@ import (
 )
 
 func (a *App) groupsHandler(c *fiber.Ctx) error {
-	// Authentication handled by middleware, no need to check session
-	groups := a.ldapCache.FindGroups()
+	userLDAP, err := a.getUserLDAP(c)
+	if err != nil {
+		return handle500(c, err)
+	}
+	defer userLDAP.Close()
+
+	groups, err := userLDAP.FindGroups()
+	if err != nil {
+		return handle500(c, err)
+	}
+
 	sort.SliceStable(groups, func(i, j int) bool {
 		return groups[i].CN() < groups[j].CN()
 	})
@@ -23,13 +32,18 @@ func (a *App) groupsHandler(c *fiber.Ctx) error {
 }
 
 func (a *App) groupHandler(c *fiber.Ctx) error {
-	// Authentication handled by middleware, no need to check session
 	groupDN, err := url.PathUnescape(c.Params("*"))
 	if err != nil {
 		return handle500(c, err)
 	}
 
-	group, unassignedUsers, err := a.loadGroupData(c, groupDN)
+	userLDAP, err := a.getUserLDAP(c)
+	if err != nil {
+		return handle500(c, err)
+	}
+	defer userLDAP.Close()
+
+	group, unassignedUsers, err := a.loadGroupDataFromLDAP(c, userLDAP, groupDN)
 	if err != nil {
 		return handle500(c, err)
 	}
@@ -49,7 +63,6 @@ type groupModifyForm struct {
 
 // nolint:dupl // Similar to userModifyHandler but operates on different entities with different forms
 func (a *App) groupModifyHandler(c *fiber.Ctx) error {
-	// Authentication handled by middleware, no need to check session
 	groupDN, err := url.PathUnescape(c.Params("*"))
 	if err != nil {
 		return handle500(c, err)
@@ -64,83 +77,102 @@ func (a *App) groupModifyHandler(c *fiber.Ctx) error {
 		return c.Redirect("/groups/" + groupDN)
 	}
 
-	// Perform the group modification using the readonly LDAP client
-	// User is already authenticated via session middleware
-	if err := a.performGroupModification(a.ldapReadonly, &form, groupDN); err != nil {
-		return a.renderGroupWithError(c, groupDN, "Failed to modify: "+err.Error())
+	userLDAP, err := a.getUserLDAP(c)
+	if err != nil {
+		return handle500(c, err)
+	}
+	defer userLDAP.Close()
+
+	// Perform the group modification using the logged-in user's LDAP connection
+	if err := a.performGroupModification(userLDAP, &form, groupDN); err != nil {
+		return a.renderGroupWithFlash(c, userLDAP, groupDN, templates.ErrorFlash("Failed to modify: "+err.Error()))
 	}
 
 	// Invalidate template cache after successful modification
 	a.invalidateTemplateCacheOnGroupModification(groupDN)
 
 	// Render success response
-	return a.renderGroupWithSuccess(c, groupDN, "Successfully modified group")
+	return a.renderGroupWithFlash(c, userLDAP, groupDN, templates.SuccessFlash("Successfully modified group"))
 }
 
-func (a *App) findUnassignedUsers(group *ldap_cache.FullLDAPGroup) []ldap.User {
-	return a.ldapCache.Users.Filter(func(u ldap.User) bool {
-		// Check if user is already a member of this group
-		for _, member := range group.Members {
-			if member.DN() == u.DN() {
-				return false
-			}
-		}
+// loadGroupDataFromLDAP loads group data directly from an LDAP client connection.
+func (a *App) loadGroupDataFromLDAP(c *fiber.Ctx, userLDAP *ldap.LDAP, groupDN string) (*ldap_cache.FullLDAPGroup, []ldap.User, error) {
+	groups, err := userLDAP.FindGroups()
+	if err != nil {
+		return nil, nil, err
+	}
 
-		return true
-	})
-}
+	group := findGroupByDN(groups, groupDN)
+	if group == nil {
+		return nil, nil, ldap.ErrGroupNotFound
+	}
 
-// loadGroupData loads and prepares group data with proper sorting
-func (a *App) loadGroupData(c *fiber.Ctx, groupDN string) (*ldap_cache.FullLDAPGroup, []ldap.User, error) {
-	thinGroup, err := a.ldapCache.FindGroupByDN(groupDN)
+	users, err := userLDAP.FindUsers()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	showDisabledUsers := c.Query("show-disabled", "0") == "1"
-	group := a.ldapCache.PopulateUsersForGroup(thinGroup, showDisabledUsers)
-	sort.SliceStable(group.Members, func(i, j int) bool {
-		return group.Members[i].CN() < group.Members[j].CN()
+	fullGroup := ldap_cache.PopulateUsersForGroupFromData(group, users, groups, showDisabledUsers)
+
+	sort.SliceStable(fullGroup.Members, func(i, j int) bool {
+		return fullGroup.Members[i].CN() < fullGroup.Members[j].CN()
 	})
-	unassignedUsers := a.findUnassignedUsers(group)
+
+	unassignedUsers := filterUnassignedUsers(users, fullGroup)
 	sort.SliceStable(unassignedUsers, func(i, j int) bool {
 		return unassignedUsers[i].CN() < unassignedUsers[j].CN()
 	})
 
-	return group, unassignedUsers, nil
+	return fullGroup, unassignedUsers, nil
 }
 
-// renderGroupWithError renders the group page with an error message
-func (a *App) renderGroupWithError(c *fiber.Ctx, groupDN, errorMsg string) error {
+// renderGroupWithFlash renders the group page with a flash message using a user LDAP connection.
+func (a *App) renderGroupWithFlash(c *fiber.Ctx, userLDAP *ldap.LDAP, groupDN string, flash templates.Flash) error {
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
-	group, unassignedUsers, err := a.loadGroupData(c, groupDN)
+
+	group, unassignedUsers, err := a.loadGroupDataFromLDAP(c, userLDAP, groupDN)
 	if err != nil {
 		return handle500(c, err)
 	}
 
 	return templates.Group(
 		group, unassignedUsers,
-		templates.Flashes(templates.ErrorFlash(errorMsg)),
+		templates.Flashes(flash),
 		a.GetCSRFToken(c),
 	).Render(c.UserContext(), c.Response().BodyWriter())
 }
 
-// renderGroupWithSuccess renders the group page with a success message
-func (a *App) renderGroupWithSuccess(c *fiber.Ctx, groupDN, successMsg string) error {
-	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
-	group, unassignedUsers, err := a.loadGroupData(c, groupDN)
-	if err != nil {
-		return handle500(c, err)
+// filterUnassignedUsers returns users not in the given group.
+func filterUnassignedUsers(allUsers []ldap.User, group *ldap_cache.FullLDAPGroup) []ldap.User {
+	memberDNs := make(map[string]struct{}, len(group.Members))
+	for _, member := range group.Members {
+		memberDNs[member.DN()] = struct{}{}
 	}
 
-	return templates.Group(
-		group, unassignedUsers,
-		templates.Flashes(templates.SuccessFlash(successMsg)),
-		a.GetCSRFToken(c),
-	).Render(c.UserContext(), c.Response().BodyWriter())
+	result := make([]ldap.User, 0)
+
+	for _, u := range allUsers {
+		if _, isMember := memberDNs[u.DN()]; !isMember {
+			result = append(result, u)
+		}
+	}
+
+	return result
 }
 
-// performGroupModification handles the actual LDAP group modification operation
+// findGroupByDN searches for a group by DN in a slice.
+func findGroupByDN(groups []ldap.Group, dn string) *ldap.Group {
+	for i := range groups {
+		if groups[i].DN() == dn {
+			return &groups[i]
+		}
+	}
+
+	return nil
+}
+
+// performGroupModification handles the actual LDAP group modification operation.
 func (a *App) performGroupModification(
 	ldapClient *ldap.LDAP, form *groupModifyForm, groupDN string,
 ) error {
@@ -148,12 +180,18 @@ func (a *App) performGroupModification(
 		if err := ldapClient.AddUserToGroup(*form.AddUser, groupDN); err != nil {
 			return err
 		}
-		a.ldapCache.OnAddUserToGroup(*form.AddUser, groupDN)
+
+		if a.ldapCache != nil {
+			a.ldapCache.OnAddUserToGroup(*form.AddUser, groupDN)
+		}
 	} else if form.RemoveUser != nil {
 		if err := ldapClient.RemoveUserFromGroup(*form.RemoveUser, groupDN); err != nil {
 			return err
 		}
-		a.ldapCache.OnRemoveUserFromGroup(*form.RemoveUser, groupDN)
+
+		if a.ldapCache != nil {
+			a.ldapCache.OnRemoveUserFromGroup(*form.RemoveUser, groupDN)
+		}
 	}
 
 	return nil
@@ -171,6 +209,5 @@ func (a *App) invalidateTemplateCacheOnGroupModification(groupDN string) {
 	a.invalidateTemplateCache("/users")
 
 	// Clear all cache entries for safety (this could be optimized further)
-	// In a high-traffic environment, you might want to be more selective
 	a.templateCache.Clear()
 }

--- a/internal/web/groups.go
+++ b/internal/web/groups.go
@@ -1,11 +1,13 @@
 package web
 
 import (
+	"errors"
 	"net/url"
 	"sort"
 
 	"github.com/gofiber/fiber/v2"
 	ldap "github.com/netresearch/simple-ldap-go"
+	"github.com/rs/zerolog/log"
 
 	"github.com/netresearch/ldap-manager/internal/ldap_cache"
 	"github.com/netresearch/ldap-manager/internal/web/templates"
@@ -43,8 +45,16 @@ func (a *App) groupHandler(c *fiber.Ctx) error {
 	}
 	defer func() { _ = userLDAP.Close() }()
 
-	group, unassignedUsers, err := a.loadGroupDataFromLDAP(c, userLDAP, groupDN)
+	showDisabled := c.Query("show-disabled", "0") == "1"
+
+	group, unassignedUsers, err := a.loadGroupDataFromLDAP(userLDAP, groupDN, showDisabled)
 	if err != nil {
+		if errors.Is(err, ldap.ErrGroupNotFound) {
+			c.Status(fiber.StatusNotFound)
+
+			return a.fourOhFourHandler(c)
+		}
+
 		return handle500(c, err)
 	}
 
@@ -74,7 +84,7 @@ func (a *App) groupModifyHandler(c *fiber.Ctx) error {
 	}
 
 	if form.RemoveUser == nil && form.AddUser == nil {
-		return c.Redirect("/groups/" + groupDN)
+		return c.Redirect("/groups/" + url.PathEscape(groupDN))
 	}
 
 	userLDAP, err := a.getUserLDAP(c)
@@ -85,11 +95,13 @@ func (a *App) groupModifyHandler(c *fiber.Ctx) error {
 
 	// Perform the group modification using the logged-in user's LDAP connection
 	if err := a.performGroupModification(userLDAP, &form, groupDN); err != nil {
-		return a.renderGroupWithFlash(c, userLDAP, groupDN, templates.ErrorFlash("Failed to modify: "+err.Error()))
+		log.Warn().Err(err).Str("groupDN", groupDN).Msg("failed to modify group")
+
+		return a.renderGroupWithFlash(c, userLDAP, groupDN, templates.ErrorFlash("Failed to modify group membership"))
 	}
 
 	// Invalidate template cache after successful modification
-	a.invalidateTemplateCacheOnGroupModification(groupDN)
+	a.invalidateTemplateCacheOnModification()
 
 	// Render success response
 	return a.renderGroupWithFlash(c, userLDAP, groupDN, templates.SuccessFlash("Successfully modified group"))
@@ -97,7 +109,7 @@ func (a *App) groupModifyHandler(c *fiber.Ctx) error {
 
 // loadGroupDataFromLDAP loads group data directly from an LDAP client connection.
 func (a *App) loadGroupDataFromLDAP(
-	c *fiber.Ctx, userLDAP *ldap.LDAP, groupDN string,
+	userLDAP *ldap.LDAP, groupDN string, showDisabledUsers bool,
 ) (*ldap_cache.FullLDAPGroup, []ldap.User, error) {
 	groups, err := userLDAP.FindGroups()
 	if err != nil {
@@ -114,7 +126,6 @@ func (a *App) loadGroupDataFromLDAP(
 		return nil, nil, err
 	}
 
-	showDisabledUsers := c.Query("show-disabled", "0") == "1"
 	fullGroup := ldap_cache.PopulateUsersForGroupFromData(group, users, groups, showDisabledUsers)
 
 	sort.SliceStable(fullGroup.Members, func(i, j int) bool {
@@ -133,7 +144,9 @@ func (a *App) loadGroupDataFromLDAP(
 func (a *App) renderGroupWithFlash(c *fiber.Ctx, userLDAP *ldap.LDAP, groupDN string, flash templates.Flash) error {
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-	group, unassignedUsers, err := a.loadGroupDataFromLDAP(c, userLDAP, groupDN)
+	showDisabled := c.Query("show-disabled", "0") == "1"
+
+	group, unassignedUsers, err := a.loadGroupDataFromLDAP(userLDAP, groupDN, showDisabled)
 	if err != nil {
 		return handle500(c, err)
 	}
@@ -147,15 +160,15 @@ func (a *App) renderGroupWithFlash(c *fiber.Ctx, userLDAP *ldap.LDAP, groupDN st
 
 // filterUnassignedUsers returns users not in the given group.
 func filterUnassignedUsers(allUsers []ldap.User, group *ldap_cache.FullLDAPGroup) []ldap.User {
-	memberDNS := make(map[string]struct{}, len(group.Members))
+	memberDNs := make(map[string]struct{}, len(group.Members))
 	for _, member := range group.Members {
-		memberDNS[member.DN()] = struct{}{}
+		memberDNs[member.DN()] = struct{}{}
 	}
 
 	result := make([]ldap.User, 0)
 
 	for _, u := range allUsers {
-		if _, isMember := memberDNS[u.DN()]; !isMember {
+		if _, isMember := memberDNs[u.DN()]; !isMember {
 			result = append(result, u)
 		}
 	}
@@ -199,17 +212,3 @@ func (a *App) performGroupModification(
 	return nil
 }
 
-// invalidateTemplateCacheOnGroupModification invalidates relevant cache entries after group modification
-func (a *App) invalidateTemplateCacheOnGroupModification(groupDN string) {
-	// Invalidate the specific group page
-	a.invalidateTemplateCache("/groups/" + groupDN)
-
-	// Invalidate groups list page (counts may have changed)
-	a.invalidateTemplateCache("/groups")
-
-	// Invalidate users pages (user membership may have changed)
-	a.invalidateTemplateCache("/users")
-
-	// Clear all cache entries for safety (this could be optimized further)
-	a.templateCache.Clear()
-}

--- a/internal/web/groups.go
+++ b/internal/web/groups.go
@@ -160,15 +160,15 @@ func (a *App) renderGroupWithFlash(c *fiber.Ctx, userLDAP *ldap.LDAP, groupDN st
 
 // filterUnassignedUsers returns users not in the given group.
 func filterUnassignedUsers(allUsers []ldap.User, group *ldap_cache.FullLDAPGroup) []ldap.User {
-	memberDNs := make(map[string]struct{}, len(group.Members))
+	memberDNS := make(map[string]struct{}, len(group.Members))
 	for _, member := range group.Members {
-		memberDNs[member.DN()] = struct{}{}
+		memberDNS[member.DN()] = struct{}{}
 	}
 
 	result := make([]ldap.User, 0)
 
 	for _, u := range allUsers {
-		if _, isMember := memberDNs[u.DN()]; !isMember {
+		if _, isMember := memberDNS[u.DN()]; !isMember {
 			result = append(result, u)
 		}
 	}
@@ -211,4 +211,3 @@ func (a *App) performGroupModification(
 
 	return nil
 }
-

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -29,7 +29,7 @@ func assertHTTPRedirect(t *testing.T, resp *http.Response) {
 	}
 }
 
-func assertHTTPStatus(t *testing.T, resp *http.Response, expectedStatus int) {
+func assertHTTPStatus(t *testing.T, resp *http.Response, expectedStatus int) { //nolint:unparam // utility function
 	t.Helper()
 	if resp.StatusCode != expectedStatus {
 		t.Errorf("Expected status %d, got %d", expectedStatus, resp.StatusCode)

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -785,7 +785,7 @@ func TestWildcardRouteWithSpecialCharacters(t *testing.T) {
 	}
 }
 
-// Test findByDN helper
+// Test findUserByDN helper
 func TestFindByDN(t *testing.T) {
 	users := []ldap.User{
 		{SAMAccountName: "user1"},
@@ -794,7 +794,7 @@ func TestFindByDN(t *testing.T) {
 
 	t.Run("returns nil error for empty DN (matches default)", func(t *testing.T) {
 		// Users with empty DN will match empty string search
-		user, err := findByDN(users, users[0].DN())
+		user, err := findUserByDN(users, users[0].DN())
 		if err != nil {
 			// If DN() returns empty for test users, this is expected
 			if user == nil {
@@ -804,7 +804,7 @@ func TestFindByDN(t *testing.T) {
 	})
 
 	t.Run("returns error for non-existent DN", func(t *testing.T) {
-		_, err := findByDN(users, "cn=nonexistent,dc=test,dc=com")
+		_, err := findUserByDN(users, "cn=nonexistent,dc=test,dc=com")
 		if !errors.Is(err, ldap.ErrUserNotFound) {
 			t.Errorf("Expected ErrUserNotFound, got %v", err)
 		}

--- a/internal/web/health.go
+++ b/internal/web/health.go
@@ -81,11 +81,16 @@ func (a *App) readinessHandler(c *fiber.Ctx) error {
 	status, reason := a.getReadinessStatus(isCacheHealthy, isWarmedUp, isPoolHealthy)
 	c.Status(fiber.StatusServiceUnavailable)
 
+	poolStatus := "unhealthy"
+	if isPoolHealthy {
+		poolStatus = "healthy"
+	}
+
 	return c.JSON(fiber.Map{
 		"status":          status,
 		"cache":           reason,
 		"warmed_up":       isWarmedUp,
-		"connection_pool": "unhealthy",
+		"connection_pool": poolStatus,
 	})
 }
 

--- a/internal/web/health.go
+++ b/internal/web/health.go
@@ -23,7 +23,7 @@ func (a *App) healthHandler(c *fiber.Ctx) error {
 	// Determine pool health
 	poolHealthy := poolStats.TotalConnections > 0
 
-	overallHealthy := cacheHealthStats.HealthStatus == "healthy" && poolHealthy
+	overallHealthy := cacheHealthStats.HealthStatus == statusHealthy && poolHealthy
 
 	// Determine status code based on health state
 	statusCode := a.getHealthStatusCode(overallHealthy, cacheHealthStats.HealthStatus, poolHealthy)
@@ -44,7 +44,7 @@ func (a *App) getHealthStatusCode(overallHealthy bool, cacheStatus string, poolH
 	if overallHealthy {
 		return fiber.StatusOK
 	}
-	if cacheStatus == "degraded" || (cacheStatus == "healthy" && !poolHealthy) {
+	if cacheStatus == "degraded" || (cacheStatus == statusHealthy && !poolHealthy) {
 		return fiber.StatusOK // Still functional but degraded
 	}
 
@@ -71,9 +71,9 @@ func (a *App) readinessHandler(c *fiber.Ctx) error {
 	if isCacheHealthy && isWarmedUp && isPoolHealthy {
 		return c.JSON(fiber.Map{
 			"status":          "ready",
-			"cache":           "healthy",
+			"cache":           statusHealthy,
 			"warmed_up":       true,
-			"connection_pool": "healthy",
+			"connection_pool": statusHealthy,
 		})
 	}
 
@@ -81,9 +81,9 @@ func (a *App) readinessHandler(c *fiber.Ctx) error {
 	status, reason := a.getReadinessStatus(isCacheHealthy, isWarmedUp, isPoolHealthy)
 	c.Status(fiber.StatusServiceUnavailable)
 
-	poolStatus := "unhealthy"
+	poolStatus := statusUnhealthy
 	if isPoolHealthy {
-		poolStatus = "healthy"
+		poolStatus = statusHealthy
 	}
 
 	return c.JSON(fiber.Map{
@@ -97,6 +97,8 @@ func (a *App) readinessHandler(c *fiber.Ctx) error {
 const (
 	statusNotReady  = "not ready"
 	statusWarmingUp = "warming up"
+	statusHealthy   = "healthy"
+	statusUnhealthy = "unhealthy"
 )
 
 // getReadinessStatus determines status and reason based on readiness conditions

--- a/internal/web/health_test.go
+++ b/internal/web/health_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/netresearch/ldap-manager/internal/ldap_cache"
 )
 
-// setupHealthTestApp creates a test application for health endpoint testing
+// setupHealthTestApp creates a test application for health endpoint testing (with service account)
 func setupHealthTestApp() *App {
 	mockClient := &testLDAPClient{
 		users: []ldap.User{
@@ -53,6 +53,30 @@ func setupHealthTestApp() *App {
 	_ = app.ldapCache.RefreshComputers() //nolint:errcheck
 
 	// Setup health routes (no authentication required)
+	f.Get("/health", app.healthHandler)
+	f.Get("/ready", app.readinessHandler)
+	f.Get("/live", app.livenessHandler)
+
+	return app
+}
+
+// setupHealthTestAppNoServiceAccount creates a test application without service account
+func setupHealthTestAppNoServiceAccount() *App {
+	sessionStore := session.New(session.Config{
+		Storage: memory.New(),
+	})
+
+	f := fiber.New(fiber.Config{
+		ErrorHandler: handle500,
+	})
+
+	app := &App{
+		ldapReadonly: nil,
+		ldapCache:    nil,
+		sessionStore: sessionStore,
+		fiber:        f,
+	}
+
 	f.Get("/health", app.healthHandler)
 	f.Get("/ready", app.readinessHandler)
 	f.Get("/live", app.livenessHandler)
@@ -114,6 +138,47 @@ func TestHealthHandler(t *testing.T) {
 	})
 }
 
+func TestHealthHandlerNoServiceAccount(t *testing.T) {
+	app := setupHealthTestAppNoServiceAccount()
+
+	t.Run("returns healthy status without service account", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/health", http.NoBody)
+		resp, err := app.fiber.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		assertHTTPStatus(t, resp, fiber.StatusOK)
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body: %v", err)
+		}
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(body, &response); err != nil {
+			t.Errorf("Response is not valid JSON: %v", err)
+		}
+
+		healthy, ok := response["overall_healthy"]
+		if !ok {
+			t.Error("Response should contain 'overall_healthy' field")
+		}
+		if healthy != true {
+			t.Errorf("Expected overall_healthy=true, got %v", healthy)
+		}
+
+		mode, ok := response["mode"]
+		if !ok {
+			t.Error("Response should contain 'mode' field")
+		}
+		if mode != "per-user credentials" {
+			t.Errorf("Expected mode='per-user credentials', got %v", mode)
+		}
+	})
+}
+
 func TestLivenessHandler(t *testing.T) {
 	app := setupHealthTestApp()
 
@@ -146,9 +211,9 @@ func TestLivenessHandler(t *testing.T) {
 			t.Errorf("Expected status 'alive', got '%v'", status)
 		}
 
-		// Check uptime field
+		// Check uptime field (present when service account is configured)
 		if _, ok := response["uptime"]; !ok {
-			t.Error("Response should contain 'uptime' field")
+			t.Error("Response should contain 'uptime' field when service account is configured")
 		}
 	})
 
@@ -163,6 +228,39 @@ func TestLivenessHandler(t *testing.T) {
 
 		if resp.StatusCode != fiber.StatusOK {
 			t.Errorf("Liveness should always return 200, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestLivenessHandlerNoServiceAccount(t *testing.T) {
+	app := setupHealthTestAppNoServiceAccount()
+
+	t.Run("returns alive status without uptime", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/live", http.NoBody)
+		resp, err := app.fiber.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		assertHTTPStatus(t, resp, fiber.StatusOK)
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body: %v", err)
+		}
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(body, &response); err != nil {
+			t.Errorf("Response is not valid JSON: %v", err)
+		}
+
+		status, ok := response["status"]
+		if !ok {
+			t.Error("Response should contain 'status' field")
+		}
+		if status != "alive" {
+			t.Errorf("Expected status 'alive', got '%v'", status)
 		}
 	})
 }
@@ -197,14 +295,38 @@ func TestReadinessHandler(t *testing.T) {
 		if _, ok := response["status"]; !ok {
 			t.Error("Response should contain 'status' field")
 		}
-		if _, ok := response["cache"]; !ok {
-			t.Error("Response should contain 'cache' field")
+	})
+}
+
+func TestReadinessHandlerNoServiceAccount(t *testing.T) {
+	app := setupHealthTestAppNoServiceAccount()
+
+	t.Run("returns ready without service account", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/ready", http.NoBody)
+		resp, err := app.fiber.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
 		}
-		if _, ok := response["warmed_up"]; !ok {
-			t.Error("Response should contain 'warmed_up' field")
+		defer func() { _ = resp.Body.Close() }()
+
+		assertHTTPStatus(t, resp, fiber.StatusOK)
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body: %v", err)
 		}
-		if _, ok := response["connection_pool"]; !ok {
-			t.Error("Response should contain 'connection_pool' field")
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(body, &response); err != nil {
+			t.Errorf("Response is not valid JSON: %v", err)
+		}
+
+		status, ok := response["status"]
+		if !ok {
+			t.Error("Response should contain 'status' field")
+		}
+		if status != "ready" {
+			t.Errorf("Expected status 'ready', got %v", status)
 		}
 	})
 }

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -31,8 +31,11 @@ func (a *App) RequireAuth() fiber.Handler {
 			return c.Redirect("/login")
 		}
 
-		// Store user DN in context for handlers to use
+		// Store user DN and username in context for handlers to use
 		c.Locals("userDN", userDN)
+		if username, ok := sess.Get("username").(string); ok {
+			c.Locals("username", username)
+		}
 
 		log.Debug().
 			Str("userDN", userDN).

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -40,8 +41,9 @@ type App struct {
 	csrfHandler   fiber.Handler
 	fiber         *fiber.App
 	logger        *slog.Logger
-	assetManifest *AssetManifest // Asset manifest for cache-busted files
-	rateLimiter   *RateLimiter   // Rate limiter for authentication endpoints
+	assetManifest  *AssetManifest // Asset manifest for cache-busted files
+	rateLimiter    *RateLimiter   // Rate limiter for authentication endpoints
+	stopCacheLog   chan struct{}  // Stops periodicCacheLogging goroutine
 }
 
 func getSessionStorage(opts *options.Opts) fiber.Storage {
@@ -153,8 +155,9 @@ func NewApp(opts *options.Opts) (*App, error) {
 		csrfHandler:   csrfHandler,
 		fiber:         f,
 		logger:        logger,
-		assetManifest: manifest,
-		rateLimiter:   NewRateLimiter(DefaultRateLimiterConfig()),
+		assetManifest:  manifest,
+		rateLimiter:    NewRateLimiter(DefaultRateLimiterConfig()),
+		stopCacheLog:   make(chan struct{}),
 	}
 
 	// Setup all routes
@@ -289,6 +292,9 @@ func (a *App) Listen(ctx context.Context, addr string) error {
 // Shutdown gracefully shuts down the application within the given context timeout.
 // It stops all background goroutines, closes connections, and releases resources.
 func (a *App) Shutdown(ctx context.Context) error {
+	log.Info().Msg("Stopping periodic cache logging...")
+	close(a.stopCacheLog)
+
 	log.Info().Msg("Stopping template cache...")
 	a.templateCache.Stop()
 
@@ -301,8 +307,9 @@ func (a *App) Shutdown(ctx context.Context) error {
 	a.rateLimiter.Stop()
 
 	log.Info().Msg("Shutting down Fiber server...")
-	if err := a.fiber.ShutdownWithContext(ctx); err != nil {
-		log.Error().Err(err).Msg("Error shutting down Fiber server")
+	shutdownErr := a.fiber.ShutdownWithContext(ctx)
+	if shutdownErr != nil {
+		log.Error().Err(shutdownErr).Msg("Error shutting down Fiber server")
 	}
 
 	log.Info().Msg("Closing LDAP connections...")
@@ -312,25 +319,33 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return shutdownErr
 }
 
 // getUserLDAP creates a user-bound LDAP client from session credentials.
 // The caller must close the returned client via defer client.Close().
+// Returns a fiber.StatusUnauthorized error if session has no credentials,
+// which handle500 will convert to a login redirect.
 func (a *App) getUserLDAP(c *fiber.Ctx) (*ldap.LDAP, error) {
 	sess, err := a.sessionStore.Get(c)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getUserLDAP: session error: %w", err)
 	}
 
 	dn, _ := sess.Get("dn").(string)
 	password, _ := sess.Get("password").(string)
 
 	if dn == "" || password == "" {
-		return nil, fiber.NewError(fiber.StatusUnauthorized, "No credentials in session")
+		return nil, fiber.NewError(fiber.StatusUnauthorized, "session expired or missing credentials")
 	}
 
-	return ldap.New(a.ldapConfig, dn, password, a.ldapOpts...)
+	client, err := ldap.New(a.ldapConfig, dn, password, a.ldapOpts...)
+	if err != nil {
+		// LDAP bind failure likely means expired/changed password → redirect to login
+		return nil, fiber.NewError(fiber.StatusUnauthorized, "LDAP connection failed, please re-login")
+	}
+
+	return client, nil
 }
 
 // templateCacheMiddleware creates middleware for template caching
@@ -359,14 +374,6 @@ func (a *App) templateCacheMiddleware() fiber.Handler {
 	}
 }
 
-// invalidateTemplateCache invalidates cache entries after data modifications
-func (a *App) invalidateTemplateCache(paths ...string) {
-	for _, path := range paths {
-		count := a.templateCache.InvalidateByPath(path)
-		log.Debug().Str("path", path).Int("invalidated", count).Msg("Template cache invalidated")
-	}
-}
-
 // cacheStatsHandler provides cache statistics for monitoring
 func (a *App) cacheStatsHandler(c *fiber.Ctx) error {
 	stats := a.templateCache.Stats()
@@ -385,8 +392,7 @@ func (a *App) poolStatsHandler(c *fiber.Ctx) error {
 	stats := a.ldapReadonly.GetPoolStats()
 
 	return c.JSON(map[string]any{
-		"stats":   stats,
-		"message": "Connection pooling is disabled - each operation creates a fresh connection",
+		"stats": stats,
 	})
 }
 
@@ -395,25 +401,29 @@ func (a *App) periodicCacheLogging() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		a.templateCache.LogStats()
-	}
-}
-
-// findByDN searches for a user by DN in a slice.
-func findByDN(users []ldap.User, dn string) (*ldap.User, error) {
-	for i := range users {
-		if users[i].DN() == dn {
-			return &users[i], nil
+	for {
+		select {
+		case <-ticker.C:
+			a.templateCache.LogStats()
+		case <-a.stopCacheLog:
+			return
 		}
 	}
-
-	return nil, ldap.ErrUserNotFound
 }
 
+
 func handle500(c *fiber.Ctx, err error) error {
+	// Redirect to login on authentication errors instead of showing 500
+	var fiberErr *fiber.Error
+	if errors.As(err, &fiberErr) && fiberErr.Code == fiber.StatusUnauthorized {
+		log.Warn().Err(err).Msg("session expired or invalid, redirecting to login")
+
+		return c.Redirect("/login")
+	}
+
 	log.Error().Err(err).Send()
 
+	c.Status(fiber.StatusInternalServerError)
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
 	return templates.FiveHundred(err).Render(c.UserContext(), c.Response().BodyWriter())
@@ -432,13 +442,8 @@ func (a *App) indexHandler(c *fiber.Ctx) error {
 	}
 	defer func() { _ = userLDAP.Close() }()
 
-	// Get username from session to look up user
-	sess, err := a.sessionStore.Get(c)
-	if err != nil {
-		return handle500(c, err)
-	}
-
-	username, _ := sess.Get("username").(string)
+	// Get username from middleware context (stored during auth)
+	username, _ := c.Locals("username").(string)
 
 	var user *ldap.User
 
@@ -457,7 +462,7 @@ func (a *App) indexHandler(c *fiber.Ctx) error {
 			return handle500(c, findErr)
 		}
 
-		user, err = findByDN(allUsers, userDN)
+		user, err = findUserByDN(allUsers, userDN)
 		if err != nil {
 			return handle500(c, err)
 		}
@@ -475,6 +480,7 @@ func (a *App) indexHandler(c *fiber.Ctx) error {
 }
 
 func (a *App) fourOhFourHandler(c *fiber.Ctx) error {
+	c.Status(fiber.StatusNotFound)
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
 	return templates.FourOhFour(c.Path()).Render(c.UserContext(), c.Response().BodyWriter())

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -41,9 +41,9 @@ type App struct {
 	csrfHandler   fiber.Handler
 	fiber         *fiber.App
 	logger        *slog.Logger
-	assetManifest  *AssetManifest // Asset manifest for cache-busted files
-	rateLimiter    *RateLimiter   // Rate limiter for authentication endpoints
-	stopCacheLog   chan struct{}  // Stops periodicCacheLogging goroutine
+	assetManifest *AssetManifest // Asset manifest for cache-busted files
+	rateLimiter   *RateLimiter   // Rate limiter for authentication endpoints
+	stopCacheLog  chan struct{}  // Stops periodicCacheLogging goroutine
 }
 
 func getSessionStorage(opts *options.Opts) fiber.Storage {
@@ -155,9 +155,9 @@ func NewApp(opts *options.Opts) (*App, error) {
 		csrfHandler:   csrfHandler,
 		fiber:         f,
 		logger:        logger,
-		assetManifest:  manifest,
-		rateLimiter:    NewRateLimiter(DefaultRateLimiterConfig()),
-		stopCacheLog:   make(chan struct{}),
+		assetManifest: manifest,
+		rateLimiter:   NewRateLimiter(DefaultRateLimiterConfig()),
+		stopCacheLog:  make(chan struct{}),
 	}
 
 	// Setup all routes
@@ -410,7 +410,6 @@ func (a *App) periodicCacheLogging() {
 		}
 	}
 }
-
 
 func handle500(c *fiber.Ctx, err error) error {
 	// Redirect to login on authentication errors instead of showing 500

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -27,12 +27,13 @@ import (
 // App represents the main web application structure.
 // Encapsulates LDAP config, readonly client, cache, session store, template cache, Fiber framework.
 // Provides centralized auth, caching, and HTTP request handling.
-// Note: Connection pooling is disabled because CheckPasswordForSAMAccountName rebinds
-// pooled connections with user credentials, causing credential contamination issues.
+// When ReadonlyUser is not configured, ldapReadonly and ldapCache are nil;
+// all interactive LDAP operations use the logged-in user's own credentials.
 type App struct {
 	ldapConfig    ldap.Config
-	ldapReadonly  *ldap.LDAP // Read-only client (no pooling)
-	ldapCache     *ldap_cache.Manager
+	ldapOpts      []ldap.Option       // LDAP client options (TLS, logging)
+	ldapReadonly  *ldap.LDAP          // Service account client (nil when not configured)
+	ldapCache     *ldap_cache.Manager // Background cache (nil when no service account)
 	sessionStore  *session.Store
 	templateCache *TemplateCache
 	csrfHandler   fiber.Handler
@@ -82,13 +83,13 @@ func createFiberApp() *fiber.App {
 }
 
 // NewApp creates a new web application instance with the provided configuration options.
-// It initializes the LDAP configuration, readonly client, session management,
+// It initializes the LDAP configuration, readonly client (if configured), session management,
 // template cache, Fiber web server, and registers all routes.
 // Returns a configured App instance ready to start serving requests via Listen().
 //
-// Note: Connection pooling is intentionally disabled. The CheckPasswordForSAMAccountName
-// method rebinds pooled connections with user credentials, contaminating the pool.
-// Each operation creates a fresh connection like ldap-selfservice-password-changer.
+// When ReadonlyUser is not configured, the app operates without a service account:
+// all LDAP operations use the logged-in user's own credentials, and
+// the background cache is disabled.
 func NewApp(opts *options.Opts) (*App, error) {
 	logger := slog.Default()
 
@@ -103,17 +104,26 @@ func NewApp(opts *options.Opts) (*App, error) {
 		}))
 	}
 
-	// Create readonly LDAP client WITHOUT connection pooling
-	// Pooling is disabled because CheckPasswordForSAMAccountName rebinds connections
-	// with user credentials, which contaminates the pool and causes timeout issues
-	ldapReadonly, err := ldap.New(
-		opts.LDAP,
-		opts.ReadonlyUser,
-		opts.ReadonlyPassword,
-		ldapOpts...,
-	)
-	if err != nil {
-		return nil, err
+	// Create readonly LDAP client only when service account is configured
+	var ldapReadonly *ldap.LDAP
+	var ldapCache *ldap_cache.Manager
+
+	if opts.ReadonlyUser != "" && opts.ReadonlyPassword != "" {
+		var err error
+		ldapReadonly, err = ldap.New(
+			opts.LDAP,
+			opts.ReadonlyUser,
+			opts.ReadonlyPassword,
+			ldapOpts...,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		ldapCache = ldap_cache.New(ldapReadonly)
+		log.Info().Msg("Service account configured, background cache enabled")
+	} else {
+		log.Info().Msg("No service account configured, using per-user LDAP credentials")
 	}
 
 	sessionStore := createSessionStore(opts)
@@ -134,8 +144,9 @@ func NewApp(opts *options.Opts) (*App, error) {
 
 	a := &App{
 		ldapConfig:    opts.LDAP,
+		ldapOpts:      ldapOpts,
 		ldapReadonly:  ldapReadonly,
-		ldapCache:     ldap_cache.New(ldapReadonly),
+		ldapCache:     ldapCache,
 		templateCache: templateCache,
 		sessionStore:  sessionStore,
 		csrfHandler:   csrfHandler,
@@ -267,7 +278,9 @@ func (a *App) setupRoutes() {
 // The context is used for graceful shutdown signaling to background goroutines.
 // This method blocks until the server is shutdown or encounters an error.
 func (a *App) Listen(ctx context.Context, addr string) error {
-	go a.ldapCache.Run(ctx)
+	if a.ldapCache != nil {
+		go a.ldapCache.Run(ctx)
+	}
 
 	return a.fiber.Listen(addr)
 }
@@ -278,8 +291,10 @@ func (a *App) Shutdown(ctx context.Context) error {
 	log.Info().Msg("Stopping template cache...")
 	a.templateCache.Stop()
 
-	log.Info().Msg("Stopping LDAP cache manager...")
-	a.ldapCache.Stop()
+	if a.ldapCache != nil {
+		log.Info().Msg("Stopping LDAP cache manager...")
+		a.ldapCache.Stop()
+	}
 
 	log.Info().Msg("Stopping rate limiter...")
 	a.rateLimiter.Stop()
@@ -297,6 +312,24 @@ func (a *App) Shutdown(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// getUserLDAP creates a user-bound LDAP client from session credentials.
+// The caller must close the returned client via defer client.Close().
+func (a *App) getUserLDAP(c *fiber.Ctx) (*ldap.LDAP, error) {
+	sess, err := a.sessionStore.Get(c)
+	if err != nil {
+		return nil, err
+	}
+
+	dn, _ := sess.Get("dn").(string)
+	password, _ := sess.Get("password").(string)
+
+	if dn == "" || password == "" {
+		return nil, fiber.NewError(fiber.StatusUnauthorized, "No credentials in session")
+	}
+
+	return ldap.New(a.ldapConfig, dn, password, a.ldapOpts...)
 }
 
 // templateCacheMiddleware creates middleware for template caching
@@ -341,16 +374,19 @@ func (a *App) cacheStatsHandler(c *fiber.Ctx) error {
 }
 
 // poolStatsHandler provides LDAP performance statistics for monitoring
-// Note: Connection pooling is disabled, so pool-specific stats will be empty
 func (a *App) poolStatsHandler(c *fiber.Ctx) error {
-	stats := a.ldapReadonly.GetPoolStats()
-
-	response := map[string]any{
-		"stats":   stats,
-		"message": "Connection pooling is disabled - each operation creates a fresh connection",
+	if a.ldapReadonly == nil {
+		return c.JSON(map[string]any{
+			"message": "No service account configured - per-user LDAP credentials in use",
+		})
 	}
 
-	return c.JSON(response)
+	stats := a.ldapReadonly.GetPoolStats()
+
+	return c.JSON(map[string]any{
+		"stats":   stats,
+		"message": "Connection pooling is disabled - each operation creates a fresh connection",
+	})
 }
 
 // periodicCacheLogging logs cache statistics periodically for monitoring
@@ -361,6 +397,17 @@ func (a *App) periodicCacheLogging() {
 	for range ticker.C {
 		a.templateCache.LogStats()
 	}
+}
+
+// findByDN searches for a user by DN in a slice.
+func findByDN(users []ldap.User, dn string) (*ldap.User, error) {
+	for i := range users {
+		if users[i].DN() == dn {
+			return &users[i], nil
+		}
+	}
+
+	return nil, ldap.ErrUserNotFound
 }
 
 func handle500(c *fiber.Ctx, err error) error {
@@ -378,13 +425,45 @@ func (a *App) indexHandler(c *fiber.Ctx) error {
 		return err
 	}
 
-	user, err := a.ldapCache.FindUserByDN(userDN)
+	userLDAP, err := a.getUserLDAP(c)
+	if err != nil {
+		return handle500(c, err)
+	}
+	defer userLDAP.Close()
+
+	// Get username from session to look up user
+	sess, err := a.sessionStore.Get(c)
 	if err != nil {
 		return handle500(c, err)
 	}
 
-	// Populate groups for the home screen
-	fullUser := a.ldapCache.PopulateGroupsForUser(user)
+	username, _ := sess.Get("username").(string)
+
+	var user *ldap.User
+
+	if username != "" {
+		user, err = userLDAP.FindUserBySAMAccountName(username)
+	}
+
+	// Fall back to finding by DN in all users
+	if user == nil || err != nil {
+		allUsers, findErr := userLDAP.FindUsers()
+		if findErr != nil {
+			return handle500(c, findErr)
+		}
+
+		user, err = findByDN(allUsers, userDN)
+		if err != nil {
+			return handle500(c, err)
+		}
+	}
+
+	groups, err := userLDAP.FindGroups()
+	if err != nil {
+		return handle500(c, err)
+	}
+
+	fullUser := ldap_cache.PopulateGroupsForUserFromData(user, groups)
 
 	// Use template caching
 	return a.templateCache.RenderWithCache(c, templates.Index(fullUser))

--- a/internal/web/template_cache.go
+++ b/internal/web/template_cache.go
@@ -24,10 +24,9 @@ type TemplateCache struct {
 }
 
 type cacheEntry struct {
-	content    []byte
-	createdAt  time.Time
-	accessedAt time.Time
-	ttl        time.Duration
+	content   []byte
+	createdAt time.Time
+	ttl       time.Duration
 }
 
 // TemplateCacheConfig holds configuration for template caching
@@ -93,8 +92,8 @@ func (tc *TemplateCache) generateCacheKey(c *fiber.Ctx, additionalData ...string
 
 // Get retrieves cached template content if available and not expired
 func (tc *TemplateCache) Get(key string) ([]byte, bool) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
 
 	entry, exists := tc.entries[key]
 	if !exists {
@@ -103,12 +102,8 @@ func (tc *TemplateCache) Get(key string) ([]byte, bool) {
 
 	// Check if entry is expired
 	if time.Since(entry.createdAt) > entry.ttl {
-		// Entry expired, but don't remove it here to avoid complex logic
 		return nil, false
 	}
-
-	// Update access time for LRU tracking
-	entry.accessedAt = time.Now()
 
 	return entry.content, true
 }
@@ -127,49 +122,11 @@ func (tc *TemplateCache) Set(key string, content []byte, ttl time.Duration) {
 		ttl = tc.defaultTTL
 	}
 
-	now := time.Now()
 	tc.entries[key] = &cacheEntry{
-		content:    content,
-		createdAt:  now,
-		accessedAt: now,
-		ttl:        ttl,
+		content:   content,
+		createdAt: time.Now(),
+		ttl:       ttl,
 	}
-}
-
-// Invalidate removes cached entries matching the given pattern
-func (tc *TemplateCache) Invalidate(pattern string) int {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-
-	count := 0
-	for key := range tc.entries {
-		// Simple pattern matching - could be enhanced with regex if needed
-		if pattern == "*" || key == pattern {
-			delete(tc.entries, key)
-			count++
-		}
-	}
-
-	return count
-}
-
-// InvalidateByPath removes all cached entries for a specific path
-func (tc *TemplateCache) InvalidateByPath(path string) int {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-
-	count := 0
-	for key := range tc.entries {
-		// Check if the key contains the path (since keys are hashed,
-		// we'll need to maintain a reverse mapping or use a different approach)
-		// For now, we'll invalidate all entries (this could be optimized)
-		if path != "" {
-			delete(tc.entries, key)
-			count++
-		}
-	}
-
-	return count
 }
 
 // Clear removes all cached entries
@@ -222,9 +179,9 @@ func (tc *TemplateCache) evictOldestUnsafe() {
 	var oldestTime time.Time
 
 	for key, entry := range tc.entries {
-		if oldestKey == "" || entry.accessedAt.Before(oldestTime) {
+		if oldestKey == "" || entry.createdAt.Before(oldestTime) {
 			oldestKey = key
-			oldestTime = entry.accessedAt
+			oldestTime = entry.createdAt
 		}
 	}
 
@@ -293,39 +250,6 @@ func (tc *TemplateCache) RenderWithCache(c *fiber.Ctx, component templ.Component
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
 	return c.Send(content)
-}
-
-// CacheMiddleware creates a Fiber middleware for template caching
-func (tc *TemplateCache) CacheMiddleware(paths ...string) fiber.Handler {
-	pathMap := make(map[string]bool)
-	for _, path := range paths {
-		pathMap[path] = true
-	}
-
-	return func(c *fiber.Ctx) error {
-		// Only cache GET requests for specified paths
-		if c.Method() != fiber.MethodGet {
-			return c.Next()
-		}
-
-		// Check if this path should be cached
-		if len(pathMap) > 0 && !pathMap[c.Path()] {
-			return c.Next()
-		}
-
-		// Generate cache key
-		cacheKey := tc.generateCacheKey(c)
-
-		// Try to serve from cache
-		if cachedContent, found := tc.Get(cacheKey); found {
-			c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
-
-			return c.Send(cachedContent)
-		}
-
-		// Not in cache, continue to handler
-		return c.Next()
-	}
 }
 
 // LogStats logs cache statistics

--- a/internal/web/template_cache_fuzz_test.go
+++ b/internal/web/template_cache_fuzz_test.go
@@ -81,40 +81,33 @@ func FuzzTemplateCacheGet(f *testing.F) {
 	})
 }
 
-// FuzzTemplateCacheInvalidate tests invalidation with fuzzed patterns
-func FuzzTemplateCacheInvalidate(f *testing.F) {
-	// Seed with patterns
-	f.Add("*")
-	f.Add("user-*")
-	f.Add("*-suffix")
-	f.Add("")
-	f.Add("exact-key")
-	f.Add("key with spaces")
-	f.Add(strings.Repeat("x", 1000))
+// FuzzTemplateCacheClear tests clear with fuzzed pre-populated cache
+func FuzzTemplateCacheClear(f *testing.F) {
+	f.Add(1)
+	f.Add(5)
+	f.Add(50)
 
-	f.Fuzz(func(t *testing.T, pattern string) {
+	f.Fuzz(func(t *testing.T, numEntries int) {
+		if numEntries < 0 {
+			numEntries = 0
+		}
+		if numEntries > 100 {
+			numEntries = 100
+		}
+
 		cache := NewTemplateCache(DefaultTemplateCacheConfig())
 		defer cache.Stop()
 
-		// Add some entries
-		cache.Set("user-1", []byte("1"), 0)
-		cache.Set("user-2", []byte("2"), 0)
-		cache.Set("group-1", []byte("3"), 0)
-
-		// Invalidate shouldn't panic
-		count := cache.Invalidate(pattern)
-
-		// Verify count is reasonable
-		if count < 0 {
-			t.Errorf("Negative invalidation count: %d", count)
+		for i := range numEntries {
+			cache.Set("key-"+string(rune(i%65536)), []byte("content"), 0)
 		}
 
-		// After "*" invalidation, cache should be empty
-		if pattern == "*" {
-			stats := cache.Stats()
-			if stats.Entries != 0 {
-				t.Errorf("Cache not empty after '*' invalidation: %d entries", stats.Entries)
-			}
+		// Clear shouldn't panic
+		cache.Clear()
+
+		stats := cache.Stats()
+		if stats.Entries != 0 {
+			t.Errorf("Cache not empty after Clear: %d entries", stats.Entries)
 		}
 	})
 }

--- a/internal/web/template_cache_test.go
+++ b/internal/web/template_cache_test.go
@@ -65,28 +65,25 @@ func TestTemplateCacheEviction(t *testing.T) {
 
 	// Fill cache to capacity
 	cache.Set("key1", []byte("content1"), 0)
+	time.Sleep(10 * time.Millisecond) // Ensure different creation times
 	cache.Set("key2", []byte("content2"), 0)
 
 	stats := cache.Stats()
 	assert.Equal(t, 2, stats.Entries)
 
-	// Access key1 to make it more recently used
-	_, found := cache.Get("key1")
-	assert.True(t, found)
-
-	// Add another entry, should evict key2 (oldest)
+	// Add another entry, should evict key1 (oldest created)
 	cache.Set("key3", []byte("content3"), 0)
 
 	stats = cache.Stats()
 	assert.Equal(t, 2, stats.Entries)
 
-	// key1 should still exist
-	_, found = cache.Get("key1")
-	assert.True(t, found)
-
-	// key2 should be evicted
-	_, found = cache.Get("key2")
+	// key1 should be evicted (oldest)
+	_, found := cache.Get("key1")
 	assert.False(t, found)
+
+	// key2 should still exist
+	_, found = cache.Get("key2")
+	assert.True(t, found)
 
 	// key3 should exist
 	_, found = cache.Get("key3")
@@ -117,7 +114,7 @@ func TestTemplateCacheClear(t *testing.T) {
 	assert.False(t, found)
 }
 
-func TestTemplateCacheInvalidation(t *testing.T) {
+func TestTemplateCacheClearOperation(t *testing.T) {
 	cache := NewTemplateCache(DefaultTemplateCacheConfig())
 	defer cache.Stop()
 
@@ -129,24 +126,17 @@ func TestTemplateCacheInvalidation(t *testing.T) {
 	stats := cache.Stats()
 	assert.Equal(t, 3, stats.Entries)
 
-	// Test pattern invalidation
-	count := cache.Invalidate("key1")
-	assert.Equal(t, 1, count)
-
-	// Verify key1 is gone
-	_, found := cache.Get("key1")
-	assert.False(t, found)
-
-	// Other keys should remain
-	_, found = cache.Get("key2")
-	assert.True(t, found)
-
-	// Test wildcard invalidation
-	count = cache.Invalidate("*")
-	assert.Equal(t, 2, count) // Should remove remaining 2 entries
+	// Clear all entries
+	cache.Clear()
 
 	stats = cache.Stats()
 	assert.Equal(t, 0, stats.Entries)
+
+	// Verify all are gone
+	_, found := cache.Get("key1")
+	assert.False(t, found)
+	_, found = cache.Get("key2")
+	assert.False(t, found)
 }
 
 func TestTemplateCacheCleanup(t *testing.T) {

--- a/internal/web/template_errors_test.go
+++ b/internal/web/template_errors_test.go
@@ -51,11 +51,11 @@ func TestTemplateCacheConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 
-	// Concurrent invalidators
+	// Concurrent clearers
 	for range 5 {
 		wg.Go(func() {
 			for range 10 {
-				cache.Invalidate("*")
+				cache.Clear()
 				time.Sleep(10 * time.Millisecond)
 			}
 		})
@@ -201,8 +201,8 @@ func TestTemplateCacheStatsAccuracy(t *testing.T) {
 	assert.Equal(t, 0, stats.Entries)
 }
 
-// TestTemplateCacheInvalidatePatterns tests various invalidation patterns
-func TestTemplateCacheInvalidatePatterns(t *testing.T) {
+// TestTemplateCacheClearAll tests clearing all entries
+func TestTemplateCacheClearAll(t *testing.T) {
 	cache := NewTemplateCache(DefaultTemplateCacheConfig())
 	defer cache.Stop()
 
@@ -215,42 +215,17 @@ func TestTemplateCacheInvalidatePatterns(t *testing.T) {
 	stats := cache.Stats()
 	assert.Equal(t, 4, stats.Entries)
 
-	// Invalidate specific entry
-	count := cache.Invalidate("user-1")
-	assert.Equal(t, 1, count)
-
-	stats = cache.Stats()
-	assert.Equal(t, 3, stats.Entries)
-
-	// Invalidate non-existent entry
-	count = cache.Invalidate("nonexistent")
-	assert.Equal(t, 0, count)
-
-	// Invalidate all
-	count = cache.Invalidate("*")
-	assert.Equal(t, 3, count)
+	// Clear all
+	cache.Clear()
 
 	stats = cache.Stats()
 	assert.Equal(t, 0, stats.Entries)
-}
 
-// TestTemplateCacheInvalidateByPath tests path-based invalidation
-func TestTemplateCacheInvalidateByPath(t *testing.T) {
-	cache := NewTemplateCache(DefaultTemplateCacheConfig())
-	defer cache.Stop()
-
-	cache.Set("key1", []byte("content1"), 0)
-	cache.Set("key2", []byte("content2"), 0)
-
-	stats := cache.Stats()
-	assert.Equal(t, 2, stats.Entries)
-
-	// Invalidate by path
-	count := cache.InvalidateByPath("/users")
-	assert.Equal(t, 2, count) // Currently invalidates all for non-empty path
-
-	stats = cache.Stats()
-	assert.Equal(t, 0, stats.Entries)
+	// Verify all entries are gone
+	_, found := cache.Get("user-1")
+	assert.False(t, found)
+	_, found = cache.Get("group-1")
+	assert.False(t, found)
 }
 
 // TestTemplateCacheStopSingleCallSafe tests that Stop can be called once safely
@@ -334,56 +309,6 @@ func TestTemplateCacheGenerateKey(t *testing.T) {
 	})
 }
 
-// TestTemplateCacheMiddleware tests the cache middleware
-func TestTemplateCacheMiddleware(t *testing.T) {
-	cache := NewTemplateCache(DefaultTemplateCacheConfig())
-	defer cache.Stop()
-
-	app := fiber.New()
-
-	// Add cache middleware for specific paths
-	app.Use(cache.CacheMiddleware("/cached"))
-
-	callCount := 0
-	app.Get("/cached", func(c *fiber.Ctx) error {
-		callCount++
-
-		return c.SendString("content")
-	})
-
-	app.Get("/not-cached", func(c *fiber.Ctx) error {
-		callCount++
-
-		return c.SendString("content")
-	})
-
-	t.Run("non-GET requests are not cached", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/cached", http.NoBody)
-		resp, err := app.Test(req)
-		require.NoError(t, err)
-		_ = resp.Body.Close()
-
-		// POST should not be cached
-		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
-	})
-
-	t.Run("non-matching paths are not cached", func(t *testing.T) {
-		callCount = 0
-
-		req := httptest.NewRequest(http.MethodGet, "/not-cached", http.NoBody)
-		resp, _ := app.Test(req)
-		_ = resp.Body.Close()
-
-		assert.Equal(t, 1, callCount)
-
-		// Second request should still call handler
-		req = httptest.NewRequest(http.MethodGet, "/not-cached", http.NoBody)
-		resp, _ = app.Test(req)
-		_ = resp.Body.Close()
-
-		assert.Equal(t, 2, callCount)
-	})
-}
 
 // TestTemplateCacheEvictionOrder tests that oldest entries are evicted first
 func TestTemplateCacheEvictionOrder(t *testing.T) {
@@ -394,18 +319,15 @@ func TestTemplateCacheEvictionOrder(t *testing.T) {
 	})
 	defer cache.Stop()
 
-	// Add entries with time gaps to establish access order
+	// Add entries with time gaps to establish creation order
 	cache.Set("first", []byte("1"), 0)
 	time.Sleep(10 * time.Millisecond)
 	cache.Set("second", []byte("2"), 0)
 	time.Sleep(10 * time.Millisecond)
 	cache.Set("third", []byte("3"), 0)
-
-	// Access "first" to make it more recently used
-	cache.Get("first")
 	time.Sleep(10 * time.Millisecond)
 
-	// Add fourth entry, should evict "second" (oldest accessed)
+	// Add fourth entry, should evict "first" (oldest created)
 	cache.Set("fourth", []byte("4"), 0)
 
 	// Check what's in cache
@@ -414,8 +336,8 @@ func TestTemplateCacheEvictionOrder(t *testing.T) {
 	_, foundThird := cache.Get("third")
 	_, foundFourth := cache.Get("fourth")
 
-	assert.True(t, foundFirst, "first should still be in cache (recently accessed)")
-	assert.False(t, foundSecond, "second should be evicted (oldest accessed)")
+	assert.False(t, foundFirst, "first should be evicted (oldest created)")
+	assert.True(t, foundSecond, "second should still be in cache")
 	assert.True(t, foundThird, "third should still be in cache")
 	assert.True(t, foundFourth, "fourth should be in cache (just added)")
 }

--- a/internal/web/template_errors_test.go
+++ b/internal/web/template_errors_test.go
@@ -309,7 +309,6 @@ func TestTemplateCacheGenerateKey(t *testing.T) {
 	})
 }
 
-
 // TestTemplateCacheEvictionOrder tests that oldest entries are evicted first
 func TestTemplateCacheEvictionOrder(t *testing.T) {
 	cache := NewTemplateCache(TemplateCacheConfig{

--- a/internal/web/templates/logged_in.templ
+++ b/internal/web/templates/logged_in.templ
@@ -1,5 +1,7 @@
 package templates
 
+import "github.com/netresearch/ldap-manager/internal/version"
+
 const navbarClasses = "px-3 py-1 rounded-md flex items-center gap-2 transition-colors focus:outline-none hocus:text-text-primary max-sm:px-2 max-sm:py-2 compact:px-2 compact:py-1 comfortable:px-3 comfortable:py-2 "
 const navbarInactiveClasses = "text-text-secondary hocus:bg-surface-elevated"
 const navbarActiveClasses = "text-text-primary bg-surface-elevated"
@@ -63,6 +65,21 @@ templ loggedIn(current, title string, flashes []Flash) {
 				}
 				{ children... }
 			</div>
+			<footer class="mt-auto border-t border-border py-3 text-center text-xs text-text-secondary">
+				<p>
+					Powered by
+					<a
+						href="https://github.com/netresearch/ldap-manager"
+						class="break-keep outline-none transition-colors hocus:text-text-primary hocus:underline"
+						title="View project on GitHub"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						netresearch/ldap-manager
+					</a>
+				</p>
+				<p>{ version.FormatVersion() }</p>
+			</footer>
 		</div>
 	}
 }

--- a/internal/web/users.go
+++ b/internal/web/users.go
@@ -168,15 +168,15 @@ func (a *App) renderUserWithFlash(c *fiber.Ctx, userLDAP *ldap.LDAP, userDN stri
 
 // filterUnassignedGroups returns groups the user is not a member of.
 func filterUnassignedGroups(allGroups []ldap.Group, user *ldap_cache.FullLDAPUser) []ldap.Group {
-	memberGroupDNs := make(map[string]struct{}, len(user.Groups))
+	memberGroupDNS := make(map[string]struct{}, len(user.Groups))
 	for _, g := range user.Groups {
-		memberGroupDNs[g.DN()] = struct{}{}
+		memberGroupDNS[g.DN()] = struct{}{}
 	}
 
 	result := make([]ldap.Group, 0)
 
 	for _, g := range allGroups {
-		if _, isMember := memberGroupDNs[g.DN()]; !isMember {
+		if _, isMember := memberGroupDNS[g.DN()]; !isMember {
 			result = append(result, g)
 		}
 	}

--- a/internal/web/users.go
+++ b/internal/web/users.go
@@ -3,11 +3,13 @@ package web
 // HTTP handlers for user management endpoints.
 
 import (
+	"errors"
 	"net/url"
 	"sort"
 
 	"github.com/gofiber/fiber/v2"
 	ldap "github.com/netresearch/simple-ldap-go"
+	"github.com/rs/zerolog/log"
 
 	"github.com/netresearch/ldap-manager/internal/ldap_cache"
 	"github.com/netresearch/ldap-manager/internal/web/templates"
@@ -60,6 +62,12 @@ func (a *App) userHandler(c *fiber.Ctx) error {
 
 	user, unassignedGroups, err := a.loadUserDataFromLDAP(userLDAP, userDN)
 	if err != nil {
+		if errors.Is(err, ldap.ErrUserNotFound) {
+			c.Status(fiber.StatusNotFound)
+
+			return a.fourOhFourHandler(c)
+		}
+
 		return handle500(c, err)
 	}
 
@@ -89,7 +97,7 @@ func (a *App) userModifyHandler(c *fiber.Ctx) error {
 	}
 
 	if form.RemoveGroup == nil && form.AddGroup == nil {
-		return c.Redirect("/users/" + userDN)
+		return c.Redirect("/users/" + url.PathEscape(userDN))
 	}
 
 	userLDAP, err := a.getUserLDAP(c)
@@ -100,11 +108,13 @@ func (a *App) userModifyHandler(c *fiber.Ctx) error {
 
 	// Perform the user modification using the logged-in user's LDAP connection
 	if err := a.performUserModification(userLDAP, &form, userDN); err != nil {
-		return a.renderUserWithFlash(c, userLDAP, userDN, templates.ErrorFlash("Failed to modify: "+err.Error()))
+		log.Warn().Err(err).Str("userDN", userDN).Msg("failed to modify user")
+
+		return a.renderUserWithFlash(c, userLDAP, userDN, templates.ErrorFlash("Failed to modify user membership"))
 	}
 
 	// Invalidate template cache after successful modification
-	a.invalidateTemplateCacheOnUserModification(userDN)
+	a.invalidateTemplateCacheOnModification()
 
 	// Render success response
 	return a.renderUserWithFlash(c, userLDAP, userDN, templates.SuccessFlash("Successfully modified user"))
@@ -117,7 +127,7 @@ func (a *App) loadUserDataFromLDAP(userLDAP *ldap.LDAP, userDN string) (*ldap_ca
 		return nil, nil, err
 	}
 
-	user, err := findByDN(allUsers, userDN)
+	user, err := findUserByDN(allUsers, userDN)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,20 +168,31 @@ func (a *App) renderUserWithFlash(c *fiber.Ctx, userLDAP *ldap.LDAP, userDN stri
 
 // filterUnassignedGroups returns groups the user is not a member of.
 func filterUnassignedGroups(allGroups []ldap.Group, user *ldap_cache.FullLDAPUser) []ldap.Group {
-	memberGroupDNS := make(map[string]struct{}, len(user.Groups))
+	memberGroupDNs := make(map[string]struct{}, len(user.Groups))
 	for _, g := range user.Groups {
-		memberGroupDNS[g.DN()] = struct{}{}
+		memberGroupDNs[g.DN()] = struct{}{}
 	}
 
 	result := make([]ldap.Group, 0)
 
 	for _, g := range allGroups {
-		if _, isMember := memberGroupDNS[g.DN()]; !isMember {
+		if _, isMember := memberGroupDNs[g.DN()]; !isMember {
 			result = append(result, g)
 		}
 	}
 
 	return result
+}
+
+// findUserByDN searches for a user by DN in a slice.
+func findUserByDN(users []ldap.User, dn string) (*ldap.User, error) {
+	for i := range users {
+		if users[i].DN() == dn {
+			return &users[i], nil
+		}
+	}
+
+	return nil, ldap.ErrUserNotFound
 }
 
 // performUserModification handles the actual LDAP user modification operation.
@@ -199,17 +220,9 @@ func (a *App) performUserModification(
 	return nil
 }
 
-// invalidateTemplateCacheOnUserModification invalidates relevant cache entries after user modification
-func (a *App) invalidateTemplateCacheOnUserModification(userDN string) {
-	// Invalidate the specific user page
-	a.invalidateTemplateCache("/users/" + userDN)
-
-	// Invalidate users list page (counts may have changed)
-	a.invalidateTemplateCache("/users")
-
-	// Invalidate groups pages (group membership may have changed)
-	a.invalidateTemplateCache("/groups")
-
-	// Clear all cache entries for safety (this could be optimized further)
+// invalidateTemplateCacheOnModification clears the template cache after any modification.
+// Membership changes can affect multiple pages, so we clear the entire cache.
+func (a *App) invalidateTemplateCacheOnModification() {
 	a.templateCache.Clear()
+	log.Debug().Msg("Template cache cleared after modification")
 }


### PR DESCRIPTION
## Summary

- **Fix "Insufficient Access Rights" bug**: Write operations (add/remove group members) now use the logged-in user's own LDAP connection instead of the readonly service account
- **Per-user LDAP reads**: All interactive reads also use user credentials, respecting per-user AD ACLs
- **Optional service account**: `LDAP_READONLY_USER` / `LDAP_READONLY_PASSWORD` are no longer required — when omitted, login uses AD UPN bind (`user@domain`) and background cache is disabled

## Changes

| File | Change |
|------|--------|
| `internal/options/app.go` | Make readonly user/password optional |
| `internal/web/auth.go` | Store credentials in session; UPN bind support |
| `internal/web/server.go` | `getUserLDAP()` helper; conditional cache init |
| `internal/web/groups.go` | Use user LDAP for reads + writes |
| `internal/web/users.go` | Use user LDAP for reads + writes |
| `internal/web/computers.go` | Use user LDAP for reads |
| `internal/web/health.go` | Handle nil cache/readonly gracefully |
| `internal/ldap_cache/manager.go` | Standalone population functions |

## Security

Password is stored in **server-side session** (memory or bbolt). Only the session ID cookie reaches the browser. This is the standard pattern for LDAP web apps (phpLDAPadmin, FusionDirectory, etc.).

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` clean
- [ ] Manual test: login without readonly user configured, browse users/groups, add/remove group members
- [ ] Manual test: login with readonly user configured, verify health endpoints return cache metrics