### PR TITLE
test: address 17 Copilot-flagged test-rigor concerns from #548

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -5,7 +5,12 @@ template: go-app
 intentional-drift:
 - path: .github/workflows/ci.yml
   reason: 'TypeScript/templ frontend assets must be built via bun before go test;
-    requires setup-bun + pre-build-cmd at caller level. Custom test-flags pass
-    -coverpkg to exclude the auto-generated internal/web/templates package from
-    the coverage calculation (its *_templ.go files contain framework-internal
-    defer/error branches unreachable from unit tests).'
+    requires setup-bun + pre-build-cmd at caller level. The reusable go-check
+    workflow has no hook between "go test" and coverage threshold enforcement,
+    so we disable its build-test job and run an inline build-test-coverage job
+    that expands -coverpkg to include internal/web/templates/... and
+    post-filters generated *_templ.go lines from coverage.out before enforcing
+    the 80% threshold. This keeps authored helpers in the templates package
+    (flash.go, specializeUsers/Groups/Computers, formatLastLogon) in the
+    numerator while excluding the framework-internal defer/error branches of
+    generated templ code.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ permissions:
   contents: read
 
 jobs:
+  # Primary quality pipeline. We disable the reusable workflow's
+  # build-test job (including coverage threshold enforcement) because
+  # the reusable workflow has no hook between "go test" and threshold
+  # enforcement, and we need to post-filter *_templ.go lines from
+  # coverage.out. The build-test-coverage job below replaces it.
   go-check:
     uses: netresearch/.github/.github/workflows/go-check.yml@main
     with:
+      enable-build-test: false
       enable-smoke-fast-feedback: true
       enable-fuzz: true
       enable-license-check: true
-      enable-codecov: true
-      # Exclude the auto-generated internal/web/templates package from the
-      # coverage calculation: the *_templ.go files are produced by the templ
-      # CLI and contain many framework-internal defer/error branches that
-      # cannot be reached from unit tests. Authored-code coverage is the
-      # metric that matters for the fleet-wide 80% floor.
-      test-flags: "-race -covermode=atomic -coverprofile=coverage.out -coverpkg=github.com/netresearch/ldap-manager/cmd/...,github.com/netresearch/ldap-manager/internal/ldap_cache/...,github.com/netresearch/ldap-manager/internal/options/...,github.com/netresearch/ldap-manager/internal/retry/...,github.com/netresearch/ldap-manager/internal/version/...,github.com/netresearch/ldap-manager/internal/web"
+      enable-codecov: false
       setup-bun: true
       pre-build-cmd: "go install github.com/a-h/templ/cmd/templ@latest && bun install --frozen-lockfile && bun run build:assets"
     permissions:
@@ -35,3 +35,80 @@ jobs:
       security-events: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Replacement for the reusable workflow's build-test + coverage
+  # enforcement, with post-filtering of generated *_templ.go lines so
+  # authored helpers in internal/web/templates (flash.go,
+  # specializeUsers/Groups/Computers, formatLastLogon, etc.) count
+  # toward the fleet-wide 80% coverage floor, while framework-internal
+  # defer/error branches in the generated templ code do not.
+  build-test-coverage:
+    name: Build & Test (with templ-filtered coverage)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      COVERAGE_THRESHOLD: "80"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Pre-build (templ + frontend assets)
+        run: |
+          go install github.com/a-h/templ/cmd/templ@latest
+          bun install --frozen-lockfile
+          bun run build:assets
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build -v ./...
+
+      - name: go test (with coverage)
+        run: |
+          go test -v -race -covermode=atomic -coverprofile=coverage.raw.out \
+            -coverpkg=github.com/netresearch/ldap-manager/cmd/...,github.com/netresearch/ldap-manager/internal/ldap_cache/...,github.com/netresearch/ldap-manager/internal/options/...,github.com/netresearch/ldap-manager/internal/retry/...,github.com/netresearch/ldap-manager/internal/version/...,github.com/netresearch/ldap-manager/internal/web/... \
+            ./...
+
+      - name: Filter generated *_templ.go lines from coverage
+        run: |
+          set -euo pipefail
+          # Generated *_templ.go files contain many framework-internal
+          # defer/error branches that unit tests cannot reasonably reach.
+          # Filter them out here so the coverage total reflects only
+          # authored code, including hand-written helpers inside the
+          # internal/web/templates package.
+          grep -v '_templ\.go:' coverage.raw.out > coverage.out
+          echo "Before filter: $(wc -l <coverage.raw.out) lines"
+          echo "After filter:  $(wc -l <coverage.out) lines"
+
+      - name: Enforce coverage threshold
+        env:
+          THRESHOLD: ${{ env.COVERAGE_THRESHOLD }}
+        run: |
+          set -euo pipefail
+          TOTAL=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","",$3); print $3}')
+          echo "Total coverage (authored code only): ${TOTAL}% (threshold ${THRESHOLD}%)"
+          awk -v t="$THRESHOLD" -v a="$TOTAL" \
+            'BEGIN { if (a+0 < t+0) { printf "::error::Coverage %s%% is below threshold %s%%\n", a, t; exit 1 } }'
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          flags: unittests
+          fail_ci_if_error: false

--- a/cmd/ldap-manager/main_test.go
+++ b/cmd/ldap-manager/main_test.go
@@ -3,9 +3,11 @@ package main
 // Tests for main.go's CLI helpers.
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -51,8 +53,18 @@ func TestRunHealthCheck(t *testing.T) {
 	})
 
 	t.Run("returns 1 when no server is listening", func(t *testing.T) {
-		// Pick an unlikely high port that almost certainly has no server bound.
-		got := runHealthCheck("65535")
+		// Acquire a known-free ephemeral port from the OS, close it, and reuse
+		// the number. This avoids the flaky assumption that a hard-coded port
+		// (e.g. 65535) is available on shared CI runners.
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+
+		port := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+		_ = l.Close()
+
+		got := runHealthCheck(port)
 		if got != 1 {
 			t.Errorf("expected 1 when no server listening, got %d", got)
 		}

--- a/internal/web/handlers_authenticated_test.go
+++ b/internal/web/handlers_authenticated_test.go
@@ -115,8 +115,8 @@ func TestUserModifyHandler_AuthenticatedPaths(t *testing.T) {
 
 		// Without CSRF token → 403. With invalid session/LDAP → 302 (redirect
 		// to /login). Either code path is exercised.
-		if resp.StatusCode == 0 {
-			t.Error("got zero status code")
+		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusFound {
+			t.Errorf("expected 302 or 403, got %d", resp.StatusCode)
 		}
 	})
 }
@@ -145,8 +145,9 @@ func TestGroupModifyHandler_AuthenticatedPaths(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode == 0 {
-			t.Error("got zero status code")
+		// CSRF rejection (403) or redirect to detail page / login (302).
+		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusFound {
+			t.Errorf("expected 302 or 403, got %d", resp.StatusCode)
 		}
 	})
 
@@ -166,8 +167,8 @@ func TestGroupModifyHandler_AuthenticatedPaths(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode == 0 {
-			t.Error("got zero status code")
+		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusFound {
+			t.Errorf("expected 302 or 403, got %d", resp.StatusCode)
 		}
 	})
 
@@ -187,8 +188,8 @@ func TestGroupModifyHandler_AuthenticatedPaths(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode == 0 {
-			t.Error("got zero status code")
+		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusFound {
+			t.Errorf("expected 302 or 403, got %d", resp.StatusCode)
 		}
 	})
 }
@@ -255,12 +256,9 @@ func TestModifyHandlers_DirectNoCSRF(t *testing.T) {
 	cookies := simulatedSession(t, app)
 
 	// Mount modify handlers behind only RequireAuth (no CSRF) on a bare app
-	// so session-based auth works but CSRF does not block.
+	// so session-based auth works but CSRF does not block. Cookies are attached
+	// per-request below (see postTo); no middleware is needed for that.
 	bare := fiber.New()
-	bare.Use(func(c *fiber.Ctx) error {
-		// Attach the simulated session cookies.
-		return c.Next()
-	})
 	bare.Post("/users/*", app.RequireAuth(), app.userModifyHandler)
 	bare.Post("/groups/*", app.RequireAuth(), app.groupModifyHandler)
 
@@ -423,8 +421,8 @@ func TestAuthenticatedGETHandlers(t *testing.T) {
 
 			// Post-auth, the LDAP call fails → fiber.StatusUnauthorized
 			// → handle500 → /login redirect. 302 is the expected outcome.
-			if resp.StatusCode == 0 {
-				t.Error("zero status")
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("expected 302 redirect after LDAP failure, got %d", resp.StatusCode)
 			}
 		})
 	}

--- a/internal/web/ldap_integration_test.go
+++ b/internal/web/ldap_integration_test.go
@@ -368,8 +368,9 @@ func TestLDAPIntegration_UsersHandler(t *testing.T) {
 		resp := makeLDAPAuthRequest(t, app, "/users", cookies)
 		defer func() { _ = resp.Body.Close() }()
 
-		// Handler connects to real LDAP — success or error page
-		assert.NotEqual(t, 0, resp.StatusCode)
+		// Handler connects to real LDAP — 200 on success, 302 on redirect
+		// to /login if session LDAP bind fails.
+		assert.Contains(t, []int{http.StatusOK, http.StatusFound}, resp.StatusCode)
 		if resp.StatusCode == http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
 			assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
@@ -381,7 +382,7 @@ func TestLDAPIntegration_UsersHandler(t *testing.T) {
 		resp := makeLDAPAuthRequest(t, app, "/users?show-disabled=1", cookies)
 		defer func() { _ = resp.Body.Close() }()
 
-		assert.NotEqual(t, 0, resp.StatusCode)
+		assert.Contains(t, []int{http.StatusOK, http.StatusFound}, resp.StatusCode)
 	})
 }
 

--- a/internal/web/login_handler_test.go
+++ b/internal/web/login_handler_test.go
@@ -1,7 +1,9 @@
 package web
 
-// Tests for loginHandler POST paths: invalid credentials, rate-limit block,
-// successful login with regenerated session.
+// Tests for loginHandler POST paths: invalid credentials, empty fields,
+// rate-limit block, and logoutHandler session destruction. A live-bind
+// "success" case is not present here because it requires a real LDAP server;
+// that path is covered by the LDAP integration test suite.
 
 import (
 	"context"

--- a/internal/web/modify_handlers_test.go
+++ b/internal/web/modify_handlers_test.go
@@ -188,8 +188,11 @@ func TestGroupModifyHandler_DeeperPaths(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode == 0 {
-			t.Error("zero status")
+		// On example-server modify failure, handle500 renders the 500 page
+		// (still exercising the target branch). On success it would render
+		// the group detail page (200) or redirect (302).
+		if !intInSlice(resp.StatusCode, []int{http.StatusOK, http.StatusFound, http.StatusInternalServerError}) {
+			t.Errorf("expected 200, 302, or 500, got %d", resp.StatusCode)
 		}
 	})
 
@@ -209,8 +212,8 @@ func TestGroupModifyHandler_DeeperPaths(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode == 0 {
-			t.Error("zero status")
+		if !intInSlice(resp.StatusCode, []int{http.StatusOK, http.StatusFound, http.StatusInternalServerError}) {
+			t.Errorf("expected 200, 302, or 500, got %d", resp.StatusCode)
 		}
 	})
 }
@@ -251,8 +254,11 @@ func TestListHandlers_ExampleServer(t *testing.T) {
 			}
 			defer func() { _ = resp.Body.Close() }()
 
-			if resp.StatusCode == 0 {
-				t.Error("zero status")
+			// Example-server mocked responses render a page (200), redirect to
+			// /login on auth failure (302), or render the 500 page on a
+			// downstream LDAP modify failure. Never 0.
+			if !intInSlice(resp.StatusCode, []int{http.StatusOK, http.StatusFound, http.StatusInternalServerError}) {
+				t.Errorf("expected 200, 302, or 500, got %d", resp.StatusCode)
 			}
 		})
 	}

--- a/internal/web/server_coverage_test.go
+++ b/internal/web/server_coverage_test.go
@@ -27,6 +27,11 @@ import (
 // newAppForCoverage creates a fully-wired *App without any real LDAP
 // connection. Using `readonly-user = ""` skips the ldap.New() call inside
 // NewApp so the test does not attempt to dial a directory server.
+//
+// The returned App is registered with t.Cleanup so its background goroutines
+// (periodicCacheLogging, template-cache cleanup, rate-limiter cleanup) are
+// shut down when the test ends. This prevents goroutine leaks that could
+// cause flakes in -race mode across the test binary's lifetime.
 func newAppForCoverage(t *testing.T) (*App, string) {
 	t.Helper()
 
@@ -62,7 +67,27 @@ func newAppForCoverage(t *testing.T) (*App, string) {
 		t.Fatalf("NewApp failed: %v", err)
 	}
 
+	registerAppShutdown(t, app)
+
 	return app, tmp
+}
+
+// registerAppShutdown arranges for app.Shutdown to run when the test ends,
+// guarding against double-close of app.stopCacheLog when a test also calls
+// Shutdown explicitly. Safe to call once per App.
+func registerAppShutdown(t *testing.T, app *App) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		// Defensive: Shutdown closes stopCacheLog unconditionally. If a test
+		// already called Shutdown, avoid panicking on double-close.
+		defer func() { _ = recover() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		_ = app.Shutdown(ctx)
+	})
 }
 
 // chdirToRepoRoot changes the working directory so the "internal/web/static/manifest.json"
@@ -157,7 +182,8 @@ func TestNewApp_WithPersistSessions(t *testing.T) {
 		t.Fatalf("NewApp: %v", err)
 	}
 
-	// Shutdown cleanly so the bbolt file is released.
+	// Shutdown cleanly so the bbolt file is released. registerAppShutdown is
+	// not used here because this test asserts on the Shutdown return value.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -196,6 +222,8 @@ func TestNewApp_TLSSkipVerify(t *testing.T) {
 		t.Fatalf("NewApp with TLSSkipVerify: %v", err)
 	}
 
+	registerAppShutdown(t, app)
+
 	if len(app.ldapOpts) < 2 {
 		t.Errorf("expected at least 2 LDAP opts with TLS skip verify, got %d", len(app.ldapOpts))
 	}
@@ -225,23 +253,30 @@ func TestCreateFiberApp_HasExpectedConfig(t *testing.T) {
 func TestApp_RoutesRegistered(t *testing.T) {
 	app, _ := newAppForCoverage(t)
 
-	// Verify routes respond. Most protected routes redirect to /login because
-	// we have no session; that still proves the route is registered.
+	// Verify routes respond with their expected status codes. Protected routes
+	// redirect to /login (302) because we have no session; that still proves
+	// the route is registered. Health endpoints answer 200 directly.
 	routes := []struct {
-		method string
-		path   string
+		method    string
+		path      string
+		wantCodes []int // accept any of these status codes
 	}{
-		{http.MethodGet, "/"},
-		{http.MethodGet, "/users"},
-		{http.MethodGet, "/groups"},
-		{http.MethodGet, "/computers"},
-		{http.MethodGet, "/login"},
-		{http.MethodGet, "/logout"},
-		{http.MethodGet, "/health"},
-		{http.MethodGet, "/health/ready"},
-		{http.MethodGet, "/health/live"},
-		{http.MethodGet, "/debug/cache"},
-		{http.MethodGet, "/debug/ldap-pool"},
+		// Protected routes without auth → 302 redirect to /login
+		{http.MethodGet, "/", []int{http.StatusFound}},
+		{http.MethodGet, "/users", []int{http.StatusFound}},
+		{http.MethodGet, "/groups", []int{http.StatusFound}},
+		{http.MethodGet, "/computers", []int{http.StatusFound}},
+		{http.MethodGet, "/logout", []int{http.StatusFound}},
+		{http.MethodGet, "/debug/cache", []int{http.StatusFound}},
+		{http.MethodGet, "/debug/ldap-pool", []int{http.StatusFound}},
+		// Login renders the form on GET → 200
+		{http.MethodGet, "/login", []int{http.StatusOK}},
+		// Health endpoints are public and respond 200 when components are healthy,
+		// or 503 when the LDAP cache is not ready (the latter is the default in
+		// this no-service-account test fixture).
+		{http.MethodGet, "/health", []int{http.StatusOK, http.StatusServiceUnavailable}},
+		{http.MethodGet, "/health/ready", []int{http.StatusOK, http.StatusServiceUnavailable}},
+		{http.MethodGet, "/health/live", []int{http.StatusOK, http.StatusServiceUnavailable}},
 	}
 
 	for _, r := range routes {
@@ -254,29 +289,30 @@ func TestApp_RoutesRegistered(t *testing.T) {
 			}
 			defer func() { _ = resp.Body.Close() }()
 
-			// A registered route should never return the built-in 404 handler's 404.
-			// (The app's 404 handler still returns 404 for truly unknown paths.)
-			if resp.StatusCode == 0 {
-				t.Errorf("route %s %s: got zero status code", r.method, r.path)
+			if !intInSlice(resp.StatusCode, r.wantCodes) {
+				t.Errorf("route %s %s: got status %d, want one of %v",
+					r.method, r.path, resp.StatusCode, r.wantCodes)
 			}
 		})
 	}
-
-	// Clean shutdown — exercises the shutdown path's periodic-cache-log stop.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	if err := app.Shutdown(ctx); err != nil {
-		t.Fatalf("Shutdown: %v", err)
-	}
 }
 
-func TestApp_ListenCancelled(t *testing.T) {
+// intInSlice reports whether needle is in haystack.
+func intInSlice(needle int, haystack []int) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestApp_ListenGracefulShutdown(t *testing.T) {
 	app, _ := newAppForCoverage(t)
 
-	// Pick an ephemeral port we reserve just to know what Listen will try.
-	// We launch Listen in a goroutine and then Shutdown immediately so it
-	// returns cleanly. The goal is only to cover the Listen() function body.
+	// Reserve an ephemeral port to know what Listen will bind to. Close the
+	// reservation before Listen runs so Listen can claim the port.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -285,16 +321,15 @@ func TestApp_ListenCancelled(t *testing.T) {
 	addr := l.Addr().String()
 	_ = l.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-
+	// App.Listen forwards to fiber.Listen which does NOT observe the passed
+	// context (see server.go). Graceful shutdown is triggered by Shutdown(),
+	// not by ctx cancellation, so we use a Background context here to avoid
+	// suggesting otherwise.
 	errCh := make(chan error, 1)
-	go func() { errCh <- app.Listen(ctx, addr) }()
+	go func() { errCh <- app.Listen(context.Background(), addr) }()
 
-	// Give Listen a moment to bind; then trigger shutdown via context cancel
-	// and an explicit Shutdown call.
+	// Give Listen a moment to bind, then trigger graceful shutdown.
 	time.Sleep(150 * time.Millisecond)
-
-	cancel()
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer shutdownCancel()
@@ -304,10 +339,13 @@ func TestApp_ListenCancelled(t *testing.T) {
 	}
 
 	select {
-	case <-errCh:
-		// Any return value is acceptable; we only care Listen ran.
+	case err := <-errCh:
+		// fiber.Listen returns nil when shut down cleanly.
+		if err != nil {
+			t.Logf("Listen returned err=%v (nil after shutdown is expected)", err)
+		}
 	case <-time.After(2 * time.Second):
-		t.Log("Listen did not return within 2s (nil returned after shutdown is expected)")
+		t.Fatal("Listen did not return within 2s after Shutdown")
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -460,9 +460,13 @@ func TestAuthenticatedHandlers_LDAPConnectionFails(t *testing.T) {
 			resp := makeAuthRequest(t, app, path, cookies)
 			defer func() { _ = resp.Body.Close() }()
 
-			// Should either redirect to login (LDAP failure → unauthorized)
-			// or return an error page — NOT panic
-			assert.NotEqual(t, 0, resp.StatusCode)
+			// Should either redirect to login (LDAP failure → unauthorized),
+			// return an error page (404 for "user not found", 500 otherwise),
+			// or render successfully — NOT 0.
+			assert.Contains(t,
+				[]int{http.StatusOK, http.StatusFound, http.StatusNotFound, http.StatusInternalServerError},
+				resp.StatusCode,
+				"unexpected status %d for GET %s", resp.StatusCode, path)
 		})
 	}
 }

--- a/internal/web/templates/render_test.go
+++ b/internal/web/templates/render_test.go
@@ -17,6 +17,7 @@ import (
 
 	templruntime "github.com/a-h/templ/runtime"
 	ldap "github.com/netresearch/simple-ldap-go"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netresearch/ldap-manager/internal/ldap_cache"
 )
@@ -157,11 +158,12 @@ func TestRender_Users(t *testing.T) {
 		}
 	}
 
-	// Variant: empty users list (exercises "no users" branch)
+	// Variant: empty users list (exercises "no users" branch). Assert the
+	// template still produces output and does not error.
 	var emptyBuf bytes.Buffer
-	mustRender(t, "Users-empty", func() error {
-		return Users(nil, false, Flashes()).Render(ctx, &emptyBuf)
-	})
+	require.NoError(t, Users(nil, false, Flashes()).Render(ctx, &emptyBuf),
+		"empty Users render should not error")
+	require.NotZero(t, emptyBuf.Len(), "empty Users render should still produce non-empty HTML")
 
 	// Detail: User with assigned groups, mail, description, disabled
 	userCases := []struct {
@@ -221,9 +223,11 @@ func TestRender_Groups(t *testing.T) {
 		t.Fatal("Groups produced empty output")
 	}
 
-	// Empty Groups list (covers "no groups" branch)
+	// Empty Groups list (covers "no groups" branch). Assert the render
+	// succeeds and produces non-empty output.
 	buf.Reset()
-	mustRender(t, "Groups-empty", func() error { return Groups(nil).Render(ctx, &buf) })
+	require.NoError(t, Groups(nil).Render(ctx, &buf), "empty Groups render should not error")
+	require.NotZero(t, buf.Len(), "empty Groups render should still produce non-empty HTML")
 
 	// Detail: cover populated + empty variants
 	cases := []struct {
@@ -283,8 +287,11 @@ func TestRender_Computers(t *testing.T) {
 		t.Fatal("Computers produced empty output")
 	}
 
+	// Empty Computers list (covers "no computers" branch). Assert that the
+	// render succeeds and produces non-empty output.
 	buf.Reset()
-	mustRender(t, "Computers-empty", func() error { return Computers(nil).Render(ctx, &buf) })
+	require.NoError(t, Computers(nil).Render(ctx, &buf), "empty Computers render should not error")
+	require.NotZero(t, buf.Len(), "empty Computers render should still produce non-empty HTML")
 
 	// Detail: with and without groups, enabled and disabled, with lastlogon
 	cases := []struct {
@@ -804,7 +811,9 @@ func TestRender_WithExistingBuffer(t *testing.T) {
 }
 
 // TestRender_WithCancelledContext ensures the early ctx.Err() check at the top
-// of every generated template is exercised.
+// of every generated template is exercised. With a cancelled context, Render
+// must return a non-nil error that wraps context.Canceled — anything else is
+// a real regression in the generated templ runtime.
 func TestRender_WithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -831,9 +840,12 @@ func TestRender_WithCancelledContext(t *testing.T) {
 			buf.Reset()
 			err := c.renderer()
 
-			// With a cancelled context we expect an error (context.Canceled).
+			if err == nil {
+				t.Fatalf("%s: expected non-nil error from Render with cancelled ctx, got nil", c.name)
+			}
+
 			if !errors.Is(err, context.Canceled) {
-				t.Logf("%s: got err=%v (expected context.Canceled)", c.name, err)
+				t.Errorf("%s: expected error to wrap context.Canceled, got %v", c.name, err)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #549

Follow-up to #548 (coverage 24.4% → 82.5%). Copilot flagged 17 test-quality
concerns that merged alongside the coverage uplift; this PR addresses all of
them as a focused test-rigor pass. No production code behaviour changes.

## Per-concern status

### Goroutine lifecycle (7 threads) — fixed
- `newAppForCoverage` now calls `registerAppShutdown(t, app)` which installs
  `t.Cleanup(app.Shutdown)`, shutting down `periodicCacheLogging`,
  template-cache cleanup, and rate-limiter cleanup goroutines. Every test
  built on `newAppForCoverage` (`TestNewApp_*`, `TestApp_*`,
  `TestUserModifyHandler_AuthenticatedPaths`, `TestGroupModifyHandler_*`,
  `TestModifyHandlers_DirectNoCSRF`, `TestCSRFProtectedModifyHandlers`,
  `TestAuthenticatedGETHandlers`) now tears down cleanly. The cleanup is
  defensive: if a test calls Shutdown explicitly first, the cleanup recovers
  from the `close(stopCacheLog)` panic on second call.
- `TestNewApp_WithPersistSessions` keeps its explicit Shutdown because it
  asserts on the return value; it does not also register the cleanup.

### port 65535 flaky assumption — fixed
`TestRunHealthCheck/returns 1 when no server is listening` now uses
`net.Listen("tcp", "127.0.0.1:0")` to acquire a known-free ephemeral port,
closes it, and reuses the port number.

### `testTemplateRenderError` sad-path assertion — fixed
`TestRender_WithCancelledContext` (the cancelled-context render test) now
asserts `err != nil` and `errors.Is(err, context.Canceled)` instead of only
`t.Logf`-ing on mismatch. A silent nil return from Render with a cancelled
context is now a fail.

### Comment/behaviour mismatch (no-op middleware) — fixed
Removed the `bare.Use(func(c *fiber.Ctx) error { /* attach cookies */ return c.Next() })`
block in `TestModifyHandlers_DirectNoCSRF`. Cookies are attached per-request
via `postTo`; no middleware is needed.

### No-assertion test variants — fixed
`Users(nil, ...)`, `Groups(nil)`, and `Computers(nil)` render blocks in
`render_test.go` now use `require.NoError` + `require.NotZero(buf.Len())` so
the empty-state branch is actually verified.

### `-coverpkg` scope too wide — fixed
The reusable `netresearch/.github/.github/workflows/go-check.yml` has no hook
between `go test` and threshold enforcement, so we cannot post-filter
`coverage.out` via inputs. Fix:
- Call the reusable workflow with `enable-build-test: false` and
  `enable-codecov: false`, keeping smoke/fuzz/license/security jobs.
- Add an inline `build-test-coverage` job that expands `-coverpkg` to include
  `internal/web/templates/...`, filters `*_templ.go` lines out of
  `coverage.raw.out` → `coverage.out`, then enforces the 80% threshold and
  uploads to Codecov.

Authored helpers in `internal/web/templates` (`flash.go` Flashes /
SuccessFlash / ErrorFlash / InfoFlash / IsSuccess / IsError / IsInfo /
BorderColor, `specializeUsers`/`specializeGroups`/`specializeComputers`,
`formatLastLogon`, `getNavbarClasses`) now count toward the 80% floor. The
generated `*_templ.go` files do not. `.github/template.yaml` drift note
updated.

### `StatusCode == 0` always-true assertions — fixed
Replaced the nine `StatusCode == 0` / `NotEqual(0, StatusCode)` checks across
`server_coverage_test.go`, `handlers_authenticated_test.go`,
`modify_handlers_test.go`, `server_test.go`, and `ldap_integration_test.go`
with explicit expected-code lists (200/302/403/404/500/503 as appropriate).

`TestApp_RoutesRegistered` now uses a `wantCodes []int` slice per route so
each is validated against the code(s) the registered handler actually emits
(302 for protected routes without session, 200 for `/login`, 200-or-503 for
`/health*`).

### Misleading `cancel()` in ListenCancelled — fixed
Renamed `TestApp_ListenCancelled` → `TestApp_ListenGracefulShutdown`. The
test no longer passes a cancellable context (Listen forwards to
`fiber.Listen` and doesn't observe ctx), and now asserts Listen returns
within 2s of `Shutdown()`.

### Stale file-header comment — fixed
`login_handler_test.go` header previously advertised "successful login with
regenerated session"; no such case exists. Replaced with a header that
matches actual contents and notes the success case is in the LDAP
integration suite.

## Verification

- `go test -race -timeout 120s ./...` passes all packages.
- `golangci-lint run --timeout 3m ./...` is clean (0 issues).
- Filtered coverage: **82.6%** (up from 82.5% baseline — now includes
  `flash.go` authored helpers at 100%).

## Test plan

- [x] All existing tests pass under `-race`
- [x] `golangci-lint` reports 0 issues
- [x] Filtered coverage >= 80% threshold
- [x] `flash.go` helpers visible in coverage output
- [x] `TestApp_RoutesRegistered` asserts specific status codes per route
- [x] `TestRender_WithCancelledContext` fails if Render returns nil error
- [x] `TestRunHealthCheck` no-server case uses ephemeral port