### PR TITLE
ci: sync with netresearch/.github templates/go-app

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -4,13 +4,16 @@
 template: go-app
 intentional-drift:
 - path: .github/workflows/ci.yml
-  reason: 'TypeScript/templ frontend assets must be built via bun before go test;
-    requires setup-bun + pre-build-cmd at caller level. The reusable go-check
-    workflow has no hook between "go test" and coverage threshold enforcement,
-    so we disable its build-test job and run an inline build-test-coverage job
-    that expands -coverpkg to include internal/web/templates/... and
-    post-filters generated *_templ.go lines from coverage.out before enforcing
-    the 80% threshold. This keeps authored helpers in the templates package
-    (flash.go, specializeUsers/Groups/Computers, formatLastLogon) in the
-    numerator while excluding the framework-internal defer/error branches of
-    generated templ code.'
+  reason: TypeScript/templ frontend assets must be built via bun before go test; requires
+    setup-bun + pre-build-cmd at caller level. The reusable go-check workflow has
+    no hook between "go test" and coverage threshold enforcement, so we disable its
+    build-test job and run an inline build-test-coverage job that expands -coverpkg
+    to include internal/web/templates/... and post-filters generated *_templ.go lines
+    from coverage.out before enforcing the 80% threshold. This keeps authored helpers
+    in the templates package (flash.go, specializeUsers/Groups/Computers, formatLastLogon)
+    in the numerator while excluding the framework-internal defer/error branches of
+    generated templ code.
+- path: .github/workflows/container.yml
+  reason: "platforms narrowed to linux/amd64,linux/arm64 \u2014 Dockerfile base images\
+    \ (oven/bun, golang-alpine) don't publish i386/arm-v6/arm-v7 variants, so a 5-platform\
+    \ build fails with 'no match for platform in manifest'"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,38 +11,10 @@ on:
 permissions: {}
 
 jobs:
-  detect:
-    name: Detect languages
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      contents: read
-    outputs:
-      languages: ${{ steps.detect.outputs.languages }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Detect TS/JS + Go
-        id: detect
-        run: |
-          set -euo pipefail
-          langs="go"
-          if [ -f package.json ] || [ -n "$(find . -maxdepth 3 -name '*.ts' -o -name '*.tsx' -o -name '*.mts' 2>/dev/null | head -1)" ]; then
-            langs="${langs},javascript-typescript"
-          fi
-          echo "languages=${langs}" >> "$GITHUB_OUTPUT"
-
   codeql:
-    needs: detect
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     with:
-      languages: ${{ needs.detect.outputs.languages }}
+      languages: auto
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,7 +16,7 @@ jobs:
     uses: netresearch/.github/.github/workflows/build-container.yml@main
     with:
       image-name: ${{ github.repository }}
-      platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+      platforms: linux/amd64,linux/arm64
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,3 +22,4 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-app` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.