### PR TITLE
test(e2e): close the skipped-browser-journeys gap

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -12,7 +12,12 @@ intentional-drift:
     from coverage.out before enforcing the 80% threshold. This keeps authored helpers
     in the templates package (flash.go, specializeUsers/Groups/Computers, formatLastLogon)
     in the numerator while excluding the framework-internal defer/error branches of
-    generated templ code.
+    generated templ code. Also opts into the reusable workflow's e2e tier
+    (enable-e2e-tests=true, e2e-test-packages=./internal/e2e/...) so the
+    browser-level journeys under internal/e2e/ — bootstrapped via a
+    testcontainers OpenLDAP + Playwright-driven headless Chromium against
+    an in-process ldap-manager listener — run on every PR with coverage
+    uploaded under the "e2e" Codecov flag.
 - path: .github/workflows/container.yml
   reason: "platforms narrowed to linux/amd64,linux/arm64 \u2014 Dockerfile base images\
     \ (oven/bun, golang-alpine) don't publish i386/arm-v6/arm-v7 variants, so a 5-platform\

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
       enable-license-check: true
       enable-codecov: true
       enable-integration-tests: true
+      enable-e2e-tests: true
+      # The e2e suite spins up an OpenLDAP testcontainer, installs Playwright
+      # browsers, and starts ldap-manager in-process before driving it via a
+      # headless Chromium. Coverage is reported under the "e2e" Codecov flag
+      # (see .github/codecov.yml) so unit / integration / e2e numbers remain
+      # separable. Only the internal/e2e package is gated by the build tag.
+      e2e-test-packages: "./internal/e2e/..."
       # Exclude the auto-generated internal/web/templates package from the
       # coverage calculation: the *_templ.go files are produced by the templ
       # CLI and contain many framework-internal defer/error branches that

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -1,0 +1,349 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ldap "github.com/netresearch/simple-ldap-go"
+	"github.com/playwright-community/playwright-go"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/netresearch/ldap-manager/internal/options"
+	"github.com/netresearch/ldap-manager/internal/web"
+)
+
+// Bootstrap constants shared between the pre-seeded OpenLDAP container and the
+// in-process ldap-manager app under test.
+const (
+	bootstrapBaseDN    = "dc=example,dc=com"
+	bootstrapDomain    = "example.com"
+	bootstrapOrg       = "Example Inc"
+	bootstrapAdminDN   = "cn=admin," + bootstrapBaseDN
+	bootstrapAdminPass = "adminpassword"
+
+	// Pre-seeded test user (see seedLDIF). uid is what LoginAsTestUser uses
+	// because simple-ldap-go falls back from sAMAccountName to uid on OpenLDAP.
+	bootstrapTestUser     = "testuser1"
+	bootstrapTestPassword = "password1"
+)
+
+// aclLDIF loosens the osixia/openldap default access control so any
+// authenticated user can read the directory. Without this, simple-ldap-go's
+// FindUsers/FindGroups calls from a per-user bind fail with "No Such Object"
+// because the default ACL hides the DIT root from non-admin users. The app
+// renders the home page via per-user LDAP, so /users and /groups would
+// return 500 without this loosening.
+const aclLDIF = `dn: olcDatabase={1}mdb,cn=config
+changetype: modify
+replace: olcAccess
+olcAccess: {0}to attrs=userPassword
+  by self write
+  by anonymous auth
+  by * none
+olcAccess: {1}to *
+  by users read
+  by * none
+`
+
+// seedLDIF is piped into ldapadd via the OpenLDAP container exec shell. It
+// provisions the entries the e2e journeys exercise:
+//
+//   - ou=users,   ou=groups   (standard organisational units)
+//   - uid=admin   in ou=users (the user E2E_ADMIN_USER=admin logs in as;
+//     this entry is what indexHandler/FindUsers matches so the home page
+//     renders without a 500)
+//   - uid=testuser1 in ou=users (second user for list-visibility checks)
+//   - cn=developers in ou=groups (non-empty group detail page)
+//
+// The osixia/openldap container also owns cn=admin,dc=example,dc=com (root
+// DN, password=LDAP_ADMIN_PASSWORD) — that's what the app uses as its
+// service account. Login form "admin" resolves via simple-ldap-go's
+// uid-fallback to uid=admin,ou=users,dc=example,dc=com.
+const seedLDIF = `dn: ou=users,dc=example,dc=com
+objectClass: organizationalUnit
+ou: users
+
+dn: ou=groups,dc=example,dc=com
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=admin-user,ou=users,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: admin-user
+sn: Admin
+uid: admin
+mail: admin@example.com
+userPassword: adminpassword
+description: E2E admin user
+
+dn: cn=testuser1,ou=users,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: testuser1
+sn: User
+uid: testuser1
+mail: testuser1@example.com
+userPassword: password1
+description: E2E test user
+
+dn: cn=developers,ou=groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: developers
+member: cn=admin-user,ou=users,dc=example,dc=com
+member: cn=testuser1,ou=users,dc=example,dc=com
+`
+
+// TestMain boots the e2e harness:
+//
+//  1. chdir to repo root so NewApp can load internal/web/static/manifest.json
+//  2. start a pre-seeded OpenLDAP testcontainer
+//  3. install Playwright browsers (no-op if already cached)
+//  4. start ldap-manager in-process on 127.0.0.1:<random>, wait for /health/live
+//  5. publish E2E_* env vars the per-test helpers pick up
+//
+// Any step failing aborts the whole suite with a clear message.
+func TestMain(m *testing.M) {
+	if err := chdirToRepoRoot(); err != nil {
+		log.Fatalf("e2e bootstrap: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	ldapContainer, ldapURI, err := startOpenLDAP(ctx)
+	if err != nil {
+		log.Fatalf("e2e bootstrap: start openldap: %v", err)
+	}
+	defer func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer termCancel()
+		_ = ldapContainer.Terminate(termCtx)
+	}()
+
+	if err := seedOpenLDAP(ctx, ldapContainer); err != nil {
+		log.Fatalf("e2e bootstrap: seed openldap: %v", err)
+	}
+
+	if err := playwright.Install(&playwright.RunOptions{Browsers: []string{"chromium"}}); err != nil {
+		log.Fatalf("e2e bootstrap: install playwright: %v", err)
+	}
+
+	port, err := freePort()
+	if err != nil {
+		log.Fatalf("e2e bootstrap: free port: %v", err)
+	}
+
+	app, err := web.NewApp(&options.Opts{
+		LDAP: ldap.Config{
+			Server:            ldapURI,
+			BaseDN:            bootstrapBaseDN,
+			IsActiveDirectory: false,
+		},
+		ReadonlyUser:            bootstrapAdminDN,
+		ReadonlyPassword:        bootstrapAdminPass,
+		PersistSessions:         false,
+		SessionDuration:         30 * time.Minute,
+		CookieSecure:            false, // HTTP listener under test
+		PoolMaxConnections:      5,
+		PoolMinConnections:      1,
+		PoolMaxIdleTime:         5 * time.Minute,
+		PoolMaxLifetime:         30 * time.Minute,
+		PoolHealthCheckInterval: 30 * time.Second,
+		PoolConnectionTimeout:   10 * time.Second,
+		PoolAcquireTimeout:      5 * time.Second,
+	})
+	if err != nil {
+		log.Fatalf("e2e bootstrap: new app: %v", err)
+	}
+
+	appCtx, appCancel := context.WithCancel(context.Background())
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- app.Listen(appCtx, fmt.Sprintf("127.0.0.1:%d", port)) }()
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	if err := waitForReady(ctx, baseURL); err != nil {
+		appCancel()
+		log.Fatalf("e2e bootstrap: wait for app: %v", err)
+	}
+
+	_ = os.Setenv("E2E_BASE_URL", baseURL)
+	_ = os.Setenv("E2E_ADMIN_USER", "admin")
+	_ = os.Setenv("E2E_ADMIN_PASS", bootstrapAdminPass)
+	_ = os.Setenv("E2E_TEST_USER", bootstrapTestUser)
+	_ = os.Setenv("E2E_TEST_USER_PASS", bootstrapTestPassword)
+
+	code := m.Run()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	_ = app.Shutdown(shutdownCtx)
+	shutdownCancel()
+	appCancel()
+	select {
+	case <-serverErr:
+	case <-time.After(2 * time.Second):
+	}
+
+	os.Exit(code)
+}
+
+// startOpenLDAP brings up an osixia/openldap container on a random host port
+// and returns its live ldap:// URI.
+func startOpenLDAP(ctx context.Context) (testcontainers.Container, string, error) {
+	req := testcontainers.ContainerRequest{
+		Image:        "osixia/openldap:1.5.0",
+		ExposedPorts: []string{"389/tcp"},
+		Env: map[string]string{
+			"LDAP_ORGANISATION":   bootstrapOrg,
+			"LDAP_DOMAIN":         bootstrapDomain,
+			"LDAP_ADMIN_PASSWORD": bootstrapAdminPass,
+			"LDAP_TLS":            "false",
+		},
+		WaitingFor: wait.ForLog("slapd starting").WithStartupTimeout(90 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("generic container: %w", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		return container, "", fmt.Errorf("container host: %w", err)
+	}
+	// simple-ldap-go treats server URIs containing "localhost" (among other
+	// substrings) as an example/test server and short-circuits real LDAP ops.
+	// The testcontainers Docker provider returns "localhost" on native Linux;
+	// rewrite it to 127.0.0.1 so the LDAP client actually talks to slapd.
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+	port, err := container.MappedPort(ctx, "389")
+	if err != nil {
+		return container, "", fmt.Errorf("mapped port: %w", err)
+	}
+
+	return container, fmt.Sprintf("ldap://%s:%s", host, port.Port()), nil
+}
+
+// seedOpenLDAP applies the ACL relaxation via ldapmodify (cn=config) and
+// then pipes seedLDIF into ldapadd. Eventual consistency in the container
+// means slapd may need a beat after "starting" before it accepts writes,
+// so each step retries briefly.
+func seedOpenLDAP(ctx context.Context, container testcontainers.Container) error {
+	if err := execLDAP(ctx, container, "ldapmodify", "-Y", "EXTERNAL", "-H", "ldapi:///", aclLDIF); err != nil {
+		return fmt.Errorf("apply ACL: %w", err)
+	}
+	if err := execLDAP(ctx, container, "ldapadd", "-x", "-D", bootstrapAdminDN, "-w", bootstrapAdminPass, "-H", "ldap://localhost", seedLDIF); err != nil {
+		return fmt.Errorf("apply seed: %w", err)
+	}
+	return nil
+}
+
+// execLDAP pipes the given LDIF to the given ldap* utility inside the
+// container, retrying up to 30s while slapd finishes its handshake.
+func execLDAP(ctx context.Context, container testcontainers.Container, bin string, args ...string) error {
+	// Last positional argument is the LDIF payload to pipe on stdin.
+	ldif := args[len(args)-1]
+	args = args[:len(args)-1]
+
+	quoted := make([]string, 0, len(args))
+	for _, a := range args {
+		quoted = append(quoted, shellQuote(a))
+	}
+
+	cmd := []string{
+		"bash", "-c",
+		fmt.Sprintf(`%s %s <<'LDIF'
+%sLDIF
+`, bin, strings.Join(quoted, " "), ldif),
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		exitCode, _, execErr := container.Exec(ctx, cmd)
+		if execErr == nil && exitCode == 0 {
+			return nil
+		}
+		lastErr = fmt.Errorf("%s exit=%d err=%v", bin, exitCode, execErr)
+		time.Sleep(500 * time.Millisecond)
+	}
+	return lastErr
+}
+
+// shellQuote is a minimal POSIX-safe single-quote wrapper.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// waitForReady polls /health/live until 200 OK or ctx deadline.
+func waitForReady(ctx context.Context, baseURL string) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(30 * time.Second)
+	url := baseURL + "/health/live"
+
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("ldap-manager did not become ready at %s", baseURL)
+}
+
+// freePort grabs an ephemeral localhost port from the kernel.
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// chdirToRepoRoot walks up from the current directory until it finds go.mod.
+// Matches the helper used by internal/web tests; NewApp resolves the asset
+// manifest relative to the process cwd.
+func chdirToRepoRoot() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	for dir := cwd; dir != "/" && dir != "."; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return os.Chdir(dir)
+		}
+	}
+	return fmt.Errorf("could not locate repo root from %s", cwd)
+}

--- a/internal/e2e/user_journey_test.go
+++ b/internal/e2e/user_journey_test.go
@@ -398,7 +398,7 @@ func TestResponsiveLayout(t *testing.T) {
 
 	t.Run("login page renders on mobile viewport", func(t *testing.T) {
 		page, err := browser.browser.NewPage(playwright.BrowserNewPageOptions{
-			ViewportSize: &playwright.Size{
+			Viewport: &playwright.Size{
 				Width:  375,
 				Height: 667,
 			},
@@ -416,7 +416,7 @@ func TestResponsiveLayout(t *testing.T) {
 
 	t.Run("login page renders on tablet viewport", func(t *testing.T) {
 		page, err := browser.browser.NewPage(playwright.BrowserNewPageOptions{
-			ViewportSize: &playwright.Size{
+			Viewport: &playwright.Size{
 				Width:  768,
 				Height: 1024,
 			},

--- a/internal/e2e/user_journey_test.go
+++ b/internal/e2e/user_journey_test.go
@@ -143,42 +143,97 @@ func TestUserListJourney(t *testing.T) {
 	t.Run("user list page loads", func(t *testing.T) {
 		tp.Navigate("/users")
 
-		// Should have a table or list of users
-		hasTable := tp.IsVisible("table") || tp.IsVisible("[data-testid='user-list']")
-		assert.True(t, hasTable, "User list should display users in a table or list")
+		// ldap-manager renders users as .list-container / .list-row; keep
+		// <table> selector as a fallback so this test adapts if the template
+		// layout ever swaps back.
+		hasList := tp.IsVisible("[data-search-list]") ||
+			tp.IsVisible(".list-container") ||
+			tp.IsVisible("table")
+		assert.True(t, hasList, "User list should display users in a table or list")
 	})
 
 	t.Run("user list shows user data", func(t *testing.T) {
 		tp.Navigate("/users")
 
-		// Wait for content to load
-		tp.WaitForSelector("table tbody tr, [data-testid='user-item']")
+		// Wait for either the legacy table layout or the current list layout.
+		// .First() avoids Playwright's strict-mode violation when multiple
+		// rows match.
+		err := tp.page.Locator(".list-container [data-search-item], table tbody tr, [data-testid='user-item']").First().WaitFor()
+		require.NoError(t, err)
 
-		// Should have at least one user
+		// Count entries under either layout.
 		rowCount := tp.TableRowCount("table")
+		if rowCount == 0 {
+			rows := tp.page.Locator(".list-container [data-search-item]")
+			if c, _ := rows.Count(); c > 0 {
+				rowCount = c
+			}
+		}
 		assert.Greater(t, rowCount, 0, "Should show at least one user")
 	})
 
 	t.Run("search functionality works", func(t *testing.T) {
 		tp.Navigate("/users")
 
-		searchInput := tp.page.Locator("input[type='search'], input[name='search'], input[placeholder*='search' i]")
+		// ldap-manager uses a client-side filter with data-search-input;
+		// accept the legacy selectors too for forward-compat.
+		searchInput := tp.page.Locator("[data-search-input], input[type='search'], input[name='search'], input[placeholder*='filter' i], input[placeholder*='search' i]")
 		count, _ := searchInput.Count()
 
 		if count > 0 {
-			// Search for a user
-			err := searchInput.First().Fill("test")
+			err := searchInput.First().Fill("testuser1")
 			require.NoError(t, err)
 
-			// Wait for results to update
-			tp.page.WaitForTimeout(500)
+			// Wait for the in-page JS filter to settle by polling the row
+			// count via a web expect — avoids the flaky WaitForTimeout.
+			require.NoError(t, tp.page.Locator(".list-container [data-search-item]").First().WaitFor())
 
-			// Results should be filtered
 			t.Log("Search functionality is available")
 		} else {
 			t.Skip("Search functionality not implemented")
 		}
 	})
+}
+
+// TestUserDetailJourney covers the "click a user → see DN and attributes"
+// flow that the spec calls out as a required e2e journey.
+func TestUserDetailJourney(t *testing.T) {
+	config := DefaultTestConfig()
+	browser := NewTestBrowser(t, config)
+	defer browser.Close()
+
+	page := browser.NewPage(t)
+	defer page.Close()
+	tp := NewTestPage(t, page, config)
+
+	require.NoError(t, tp.LoginAsAdmin())
+	defer tp.Logout()
+
+	tp.Navigate("/users")
+
+	// Wait for the seeded users to show up. main_test.go seeds testuser1
+	// and admin-user under ou=users; the list layout renders them as
+	// anchors inside data-search-item rows.
+	require.NoError(t, tp.page.Locator(".list-container [data-search-item] a, table tbody tr a").First().WaitFor())
+
+	userLink := tp.page.Locator(".list-container [data-search-item] a, table tbody tr a").First()
+	href, err := userLink.GetAttribute("href")
+	require.NoError(t, err)
+	require.NotEmpty(t, href, "Expected at least one user link in /users")
+
+	require.NoError(t, userLink.Click())
+	require.NoError(t, tp.page.WaitForURL("**/users/**"))
+
+	// The detail view is rendered by templates.User; it shows the CN as an
+	// H1, the DN inside a .text-text-secondary block, a "Groups:" heading,
+	// and an "Add to group" form. Verifying all four is a strong signal
+	// that the detail page actually populated from LDAP rather than
+	// falling through to a 500/empty shell.
+	assert.True(t, tp.IsVisible("h1"), "user detail should render an <h1> with the user CN")
+	assert.True(t, tp.HasText("dc=example,dc=com"),
+		"user detail should expose the DN (contains base DN)")
+	assert.True(t, tp.HasText("Groups:"), "user detail should render the Groups section header")
+	assert.True(t, tp.HasText("Add to group"), "user detail should expose the add-to-group form")
 }
 
 func TestGroupManagementJourney(t *testing.T) {
@@ -234,10 +289,20 @@ func TestErrorPagesJourney(t *testing.T) {
 	tp := NewTestPage(t, page, config)
 
 	t.Run("404 page renders for non-existent routes", func(t *testing.T) {
+		// The 404 template lives behind the authenticated layout; log in so
+		// navigation to a missing route doesn't bounce to /login first.
+		require.NoError(t, tp.LoginAsAdmin())
+		defer tp.Logout()
+
 		tp.Navigate("/this-page-does-not-exist-12345")
 
-		// Check for 404 indicator
-		has404 := tp.HasText("404") || tp.HasText("not found") || tp.HasText("Not Found")
+		// ldap-manager's FourOhFour template uses a human phrasing rather
+		// than the literal "404"; accept either so we don't couple the test
+		// to copy.
+		has404 := tp.HasText("404") ||
+			tp.HasText("not found") ||
+			tp.HasText("Not Found") ||
+			tp.HasText("does not exist")
 		assert.True(t, has404, "Should show 404 page for non-existent routes")
 	})
 }


### PR DESCRIPTION
## Summary

- Wire a working `TestMain` under `internal/e2e/` that stands up an
  OpenLDAP testcontainer (pre-seeded with `ou=users` / `ou=groups`,
  `admin-user`, `testuser1`, `developers`), installs the Playwright
  Chromium headless shell, starts ldap-manager in-process on an
  ephemeral 127.0.0.1 port, and publishes `E2E_*` env vars so the
  per-test helpers work unchanged. The suite was previously compile-
  broken (a stale `BrowserNewPageOptions.ViewportSize` field name) and
  CI never shipped an app + LDAP for it to talk to.
- Fix the `ViewportSize` → `Viewport` field name so the file builds
  under `-tags=e2e`.
- Adjust the user-list / 404 assertions to the real templ output
  (`.list-container` + `[data-search-input]` instead of `<table>`,
  "does not exist" instead of "404"), and replace the deprecated
  `WaitForTimeout` poll with a `Locator.WaitFor()` web expect.
- Add `TestUserDetailJourney` — the spec explicitly lists
  "click a user → DN + attributes render" as one of the five required
  journeys but nothing covered it before.
- Flip `enable-e2e-tests: true` on the `netresearch/.github` reusable
  `go-check` workflow with `e2e-test-packages: ./internal/e2e/...` so
  the suite runs on every PR. Coverage uploads under the existing
  `e2e` flag in [`.github/codecov.yml`](.github/codecov.yml). Record
  the opt-in on the ci.yml intentional-drift entry.

## Browser automation choice

**Playwright** (`github.com/playwright-community/playwright-go`).

The repo already committed to it — `go.mod` pins `playwright-community/
playwright-go v0.5700.1` and the existing `e2e_helpers.go`/`user_
journey_test.go` are built on its `BrowserType` / `Locator` / `Page`
API — so rewriting to chromedp would have meant throwing away ~30
working helpers plus the seven existing journey tests. Playwright's
strict-mode Locators + `WaitForURL` web-expects also give us the
assertion ergonomics the flows rely on (strict-mode violations
surfaced the list-vs-table drift on first run). `playwright.Install`
in `TestMain` is idempotent — the first CI run caches ~110 MB of
Chromium under `~/.cache/ms-playwright`, every subsequent run is a
no-op.

## Journeys covered

| # | Requirement | Where |
| - | ----------- | ----- |
| 1 | Login: `/` → `/login`, submit valid creds, land on user list | `TestLoginJourney` (login_with_valid_credentials_succeeds, logout_works_correctly), `TestProtectedRoutes` |
| 2 | User list: seeded user visible, filter/search works | `TestUserListJourney` (user_list_page_loads, user_list_shows_user_data, search_functionality_works) |
| 3 | User detail: click a user, DN + attributes render | **new** `TestUserDetailJourney` |
| 4 | Logout: back to login, cookie cleared | `TestLoginJourney/logout_works_correctly`, `TestSessionPersistence` |
| 5 | Auth negative: wrong password → stay on login with error | `TestLoginJourney/login_with_invalid_credentials_shows_error`, `TestLoginJourney/login_with_empty_credentials_shows_validation` |

Plus the suite also exercises 404 rendering, nav visibility, CSRF
token presence, password-field masking, aria labels, and mobile /
tablet viewport rendering.

## Bootstrap time

Local, warm caches:

```
go test -race -tags=e2e -coverprofile=coverage-e2e.out -covermode=atomic ./internal/e2e/...
ok  github.com/netresearch/ldap-manager/internal/e2e  17.234s  coverage: 64.8% of statements
```

Local, cold cache (first pull of osixia/openldap:1.5.0 + Playwright
Chromium Headless Shell 143.0.7499.4 download, 109.7 MiB): ~60 s
additional. The reusable `go-check` e2e job budgets 30 min
(`e2e-timeout-minutes`, default) and the actual test-execution window
is 25 min (set by the workflow), so there's plenty of headroom even
on the cold path.

## Caveats

* **OpenLDAP ACL loosening.** `osixia/openldap`'s default ACL hides
  the DIT root from non-admin users. Every `FindUsers` /
  `FindGroups` call via the per-user bind (the one the home page,
  user list, and group list all make) would return
  `LDAP Result Code 32 "No Such Object"` and handlers would 500.
  `TestMain` now applies the same permissive ACL we ship in
  `dev/acl.ldif` (`by users read`) via `ldapmodify -Y EXTERNAL` before
  seeding. Production deployments are expected to have a service
  account with broader read rights; the ACL loosening only affects
  the test container.
* **`simple-ldap-go`'s "example server" heuristic.** The library
  short-circuits real LDAP ops for any server URI whose host
  contains `localhost` (among ~15 other substrings). The
  testcontainers Docker provider returns `localhost` on native Linux
  runners, so `TestMain` rewrites the host to `127.0.0.1` before
  handing the URI to `options.Opts`.
* **Lint pedantics.** The pre-existing `e2e_helpers.go` has a handful
  of `errcheck` / `nlreturn` findings. They're invisible to CI
  because `golangci-lint-action` doesn't pass `-tags=e2e`, so the
  e2e files stay outside its visible file set. I deliberately didn't
  touch them — out of scope and would muddy the review.

## Test plan

- [ ] `go test -race -tags=e2e -coverprofile=coverage-e2e.out -covermode=atomic ./internal/e2e/...` passes locally
- [ ] `enable-e2e-tests: true` job runs green on this PR in CI
- [ ] Codecov ingests the `e2e` flag (check the PR comment)
- [ ] Template-drift job still passes (drift reason updated in
      `.github/template.yaml`)