### PR TITLE
feat(main): forward buildTime ldflag + extract testable helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,17 @@ jobs:
       goos: ${{ matrix.goos }}
       goarch: ${{ matrix.goarch }}
       goarm: ${{ matrix.goarm || '' }}
-      ldflags: "-s -w -X main.version=${{ needs.create-release.outputs.tag }} -X main.build=${{ needs.create-release.outputs.sha }}"
+      # Fleet ldflag convention: repos that want to surface release
+      # metadata declare `var version, build, buildTime string` in their
+      # main package. Each repo decides which to forward into its own
+      # version package (ofelia uses main.* directly; ldap-manager
+      # forwards into internal/version.*). Empty values are a silent
+      # no-op for repos that don't declare the corresponding var.
+      ldflags: >-
+        -s -w
+        -X main.version=${{ needs.create-release.outputs.tag }}
+        -X main.build=${{ needs.create-release.outputs.sha }}
+        -X main.buildTime=${{ github.event.head_commit.timestamp }}
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
       sbom: true

--- a/cmd/ldap-manager/main.go
+++ b/cmd/ldap-manager/main.go
@@ -27,22 +27,36 @@ const (
 )
 
 // Build-injected version metadata. Populated by release.yml's ldflags
-// (`-X main.version=<tag>`, `-X main.build=<commit-sha>`); forwarded
-// into internal/version at init() so FormatVersion() / the `version`
+// (`-X main.version=<tag>`, `-X main.build=<commit-sha>`,
+// `-X main.buildTime=<commit-timestamp>`); forwarded into
+// internal/version at init() so FormatVersion() / the `version`
 // subcommand report the release info without requiring each repo to
 // invent its own ldflag target-path convention.
 var (
-	version = ""
-	build   = ""
+	version   = ""
+	build     = ""
+	buildTime = ""
 )
 
+// forwardBuildMetadata copies the build-injected package-main vars into
+// the internal/version package. Extracted from init() to keep it
+// unit-testable without mutating global state via the init machinery.
+// Empty inputs are treated as "not injected" and leave the existing
+// internal/version defaults in place.
+func forwardBuildMetadata(v, b, t string) {
+	if v != "" {
+		internalversion.Version = v
+	}
+	if b != "" {
+		internalversion.CommitHash = b
+	}
+	if t != "" {
+		internalversion.BuildTimestamp = t
+	}
+}
+
 func init() {
-	if version != "" {
-		internalversion.Version = version
-	}
-	if build != "" {
-		internalversion.CommitHash = build
-	}
+	forwardBuildMetadata(version, build, buildTime)
 }
 
 func main() {

--- a/cmd/ldap-manager/main_test.go
+++ b/cmd/ldap-manager/main_test.go
@@ -10,7 +10,73 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	internalversion "github.com/netresearch/ldap-manager/internal/version"
 )
+
+func TestForwardBuildMetadata(t *testing.T) {
+	// Snapshot + restore so this test doesn't leak state to siblings.
+	origV, origC, origT := internalversion.Version, internalversion.CommitHash, internalversion.BuildTimestamp
+	t.Cleanup(func() {
+		internalversion.Version = origV
+		internalversion.CommitHash = origC
+		internalversion.BuildTimestamp = origT
+	})
+
+	t.Run("all values forwarded", func(t *testing.T) {
+		internalversion.Version = "dev"
+		internalversion.CommitHash = "n/a"
+		internalversion.BuildTimestamp = "n/a"
+
+		forwardBuildMetadata("v1.2.3", "abc123", "2026-04-20T00:00:00Z")
+
+		if got, want := internalversion.Version, "v1.2.3"; got != want {
+			t.Errorf("Version = %q, want %q", got, want)
+		}
+		if got, want := internalversion.CommitHash, "abc123"; got != want {
+			t.Errorf("CommitHash = %q, want %q", got, want)
+		}
+		if got, want := internalversion.BuildTimestamp, "2026-04-20T00:00:00Z"; got != want {
+			t.Errorf("BuildTimestamp = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty inputs preserve existing values", func(t *testing.T) {
+		internalversion.Version = "preserved-v"
+		internalversion.CommitHash = "preserved-c"
+		internalversion.BuildTimestamp = "preserved-t"
+
+		forwardBuildMetadata("", "", "")
+
+		if got := internalversion.Version; got != "preserved-v" {
+			t.Errorf("Version mutated to %q", got)
+		}
+		if got := internalversion.CommitHash; got != "preserved-c" {
+			t.Errorf("CommitHash mutated to %q", got)
+		}
+		if got := internalversion.BuildTimestamp; got != "preserved-t" {
+			t.Errorf("BuildTimestamp mutated to %q", got)
+		}
+	})
+
+	t.Run("partial injection", func(t *testing.T) {
+		internalversion.Version = "preserved"
+		internalversion.CommitHash = "preserved"
+		internalversion.BuildTimestamp = "preserved"
+
+		forwardBuildMetadata("v9.9.9", "", "2026-01-01T00:00:00Z")
+
+		if got, want := internalversion.Version, "v9.9.9"; got != want {
+			t.Errorf("Version = %q, want %q", got, want)
+		}
+		if got := internalversion.CommitHash; got != "preserved" {
+			t.Errorf("CommitHash mutated to %q", got)
+		}
+		if got, want := internalversion.BuildTimestamp, "2026-01-01T00:00:00Z"; got != want {
+			t.Errorf("BuildTimestamp = %q, want %q", got, want)
+		}
+	})
+}
 
 func TestIsValidPort(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

Addresses copilot-review follow-ups from [#564](https://github.com/netresearch/ldap-manager/pull/564).

### 1. BuildTimestamp actually populates

`FormatVersion()` previously reported `built at n/a` even on tagged releases because the template injected only `main.version` + `main.build`. [netresearch/.github#74](https://github.com/netresearch/.github/pull/74) extended the template with `-X main.buildTime=<commit-timestamp>`; this PR adds `var buildTime string` and forwards it into `internal/version.BuildTimestamp`.

### 2. Testable forwarding helper

Extracted the three `if X != "" { ... }` assignments into `forwardBuildMetadata(v, b, t)`. Three new test cases in `main_test.go`:

- **all values forwarded** — confirms the happy path mutates internalversion.*
- **empty inputs preserve existing values** — confirms local `go run` / untagged `go build` leaves defaults intact
- **partial injection** — confirms only the non-empty inputs land (e.g. buildTime empty on workflow_dispatch backfill still populates version + build)

Tests use snapshot/restore via `t.Cleanup` so they don't leak state.

### 3. Sync release.yml to latest template

Picks up the `-X main.buildTime=` ldflag from #74.

## Test plan

- [x] `go test -run TestForwardBuildMetadata -v ./cmd/ldap-manager/` passes (3 subtests).