### PR TITLE
docs(version): describe main vars without pinning to exact syntax

### DIFF
--- a/internal/version/doc.go
+++ b/internal/version/doc.go
@@ -17,8 +17,8 @@
 //	-X main.build=<commit-sha>
 //	-X main.buildTime=<commit-timestamp>
 //
-// cmd/ldap-manager/main.go declares matching package-level variables
-// (`var version, build, buildTime string`) and calls
+// cmd/ldap-manager/main.go declares matching package-level string
+// variables named version, build, and buildTime and calls
 // forwardBuildMetadata() at init() time to copy their values into
 // Version, CommitHash, and BuildTimestamp here. The indirection keeps
 // the fleet ldflag convention (`main.*`) uniform across every go-app


### PR DESCRIPTION
Copilot on [#566](https://github.com/netresearch/ldap-manager/pull/566): the package doc said `declares var version, build, buildTime string` as if it were a compact decl, but main.go uses a `var(...)` block with explicit empty-string initializers. Describe the variable names without implying a specific syntax to prevent future drift on trivial refactors.