### PR TITLE
docs(version): describe buildTime via auto-build-timestamp

### DIFF
--- a/cmd/ldap-manager/main.go
+++ b/cmd/ldap-manager/main.go
@@ -26,12 +26,18 @@ const (
 	defaultPort        = "3000"
 )
 
-// Build-injected version metadata. Populated by release.yml's ldflags
-// (`-X main.version=<tag>`, `-X main.build=<commit-sha>`,
-// `-X main.buildTime=<commit-timestamp>`); forwarded into
-// internal/version at init() so FormatVersion() / the `version`
-// subcommand report the release info without requiring each repo to
-// invent its own ldflag target-path convention.
+// Build-injected version metadata:
+//
+//	version   <- release.yml ldflags: -X main.version=<tag>
+//	build     <- release.yml ldflags: -X main.build=<commit-sha>
+//	buildTime <- build-go-attest.yml's auto-build-timestamp step
+//	             (ISO-8601 from `git show -s --format=%cI HEAD`);
+//	             works for tag push AND workflow_dispatch backfills
+//	             because it reads git, not github.event.head_commit.
+//
+// Forwarded into internal/version at init() so FormatVersion() / the
+// `version` subcommand report the release info without requiring each
+// repo to invent its own ldflag target-path convention.
 var (
 	version   = ""
 	build     = ""

--- a/internal/version/doc.go
+++ b/internal/version/doc.go
@@ -10,12 +10,20 @@
 // # Build-Time Injection (template-driven)
 //
 // Release builds use the shared go-app release pipeline
-// (netresearch/.github/templates/go-app/.github/workflows/release.yml),
-// which passes these ldflags to every matrix entry:
+// (netresearch/.github/templates/go-app/.github/workflows/release.yml).
+// Release metadata lands in package main via two reusable mechanisms:
+//
+//   - The release.yml ldflags input:
 //
 //	-X main.version=<tag>
 //	-X main.build=<commit-sha>
-//	-X main.buildTime=<commit-timestamp>
+//
+//   - The build-go-attest.yml `auto-build-timestamp` input (enabled by
+//     the release template), which after checkout runs
+//     `git show -s --format=%cI HEAD` and appends
+//     `-X main.buildTime=<ISO-8601>` to the effective ldflags. Works on
+//     tag pushes and workflow_dispatch backfills alike because it reads
+//     git directly instead of `github.event.head_commit.timestamp`.
 //
 // cmd/ldap-manager/main.go declares matching package-level string
 // variables named version, build, and buildTime and calls


### PR DESCRIPTION
Copilot on [#568](https://github.com/netresearch/ldap-manager/pull/568): the docs still attributed `buildTime` to a release.yml ldflag, but [netresearch/.github#77](https://github.com/netresearch/.github/pull/77) moved that injection into `build-go-attest.yml`'s `auto-build-timestamp` step (runs after checkout, resolves from git).

Update `cmd/ldap-manager/main.go` and `internal/version/doc.go` to describe the actual injection path per field so future contributors see why tag pushes and workflow_dispatch backfills both produce a populated `BuildTimestamp`.