### PR TITLE
chore(version): gofmt doc.go (golangci-lint fix)

### DIFF
--- a/internal/version/doc.go
+++ b/internal/version/doc.go
@@ -15,8 +15,8 @@
 //
 //   - The release.yml ldflags input:
 //
-//	-X main.version=<tag>
-//	-X main.build=<commit-sha>
+//     -X main.version=<tag>
+//     -X main.build=<commit-sha>
 //
 //   - The build-go-attest.yml `auto-build-timestamp` input (enabled by
 //     the release template), which after checkout runs


### PR DESCRIPTION
[#569](https://github.com/netresearch/ldap-manager/pull/569) merged with gofmt drift inside list-nested code examples — golangci-lint on main went red with `doc.go:18:1: File is not properly formatted (goimports)`. Ran `gofmt -w` locally to re-indent the nested blocks.