### PR TITLE
feat(graph): phase 3 graph view — Slice 2 (JSON endpoint)

### DIFF
--- a/internal/ldap_cache/cachetest/helpers.go
+++ b/internal/ldap_cache/cachetest/helpers.go
@@ -1,0 +1,60 @@
+// Package cachetest provides exported test helpers for seeding the
+// ldap_cache.Manager from external test packages. It uses reflection +
+// unsafe to set the unexported dn/cn fields on simple-ldap-go's Object
+// type. DO NOT import from production code — this exists for tests only.
+package cachetest
+
+import (
+	"reflect"
+	"unsafe"
+
+	ldap "github.com/netresearch/simple-ldap-go"
+
+	"github.com/netresearch/ldap-manager/internal/ldap_cache"
+)
+
+// NewUserWithDN builds a ldap.User with the unexported dn/cn fields set
+// via reflection. Use only in tests.
+func NewUserWithDN(dn, cn, sam string, enabled bool, groups []string) ldap.User {
+	u := ldap.User{SAMAccountName: sam, Enabled: enabled, Groups: groups}
+	setObjectFields(reflect.ValueOf(&u).Elem().FieldByName("Object"), dn, cn)
+
+	return u
+}
+
+// NewGroupWithDN builds a ldap.Group with unexported dn/cn populated.
+func NewGroupWithDN(dn, cn string, members []string) ldap.Group {
+	g := ldap.Group{Members: members}
+	setObjectFields(reflect.ValueOf(&g).Elem().FieldByName("Object"), dn, cn)
+
+	return g
+}
+
+// NewComputerWithDN builds a ldap.Computer with unexported dn/cn populated.
+func NewComputerWithDN(dn, cn, sam string, enabled bool, groups []string) ldap.Computer {
+	c := ldap.Computer{SAMAccountName: sam, Enabled: enabled, Groups: groups}
+	setObjectFields(reflect.ValueOf(&c).Elem().FieldByName("Object"), dn, cn)
+
+	return c
+}
+
+// Seed replaces all three caches in one call. Pass nil for any kind you
+// don't need to set.
+func Seed(m *ldap_cache.Manager, users []ldap.User, groups []ldap.Group, computers []ldap.Computer) {
+	if users != nil {
+		m.SetUsersForTesting(users)
+	}
+	if groups != nil {
+		m.SetGroupsForTesting(groups)
+	}
+	if computers != nil {
+		m.SetComputersForTesting(computers)
+	}
+}
+
+func setObjectFields(obj reflect.Value, dn, cn string) {
+	dnField := obj.FieldByName("dn")
+	cnField := obj.FieldByName("cn")
+	reflect.NewAt(dnField.Type(), unsafe.Pointer(dnField.UnsafeAddr())).Elem().SetString(dn) //nolint:gosec
+	reflect.NewAt(cnField.Type(), unsafe.Pointer(cnField.UnsafeAddr())).Elem().SetString(cn) //nolint:gosec
+}

--- a/internal/ldap_cache/cachetest/helpers.go
+++ b/internal/ldap_cache/cachetest/helpers.go
@@ -55,6 +55,9 @@ func Seed(m *ldap_cache.Manager, users []ldap.User, groups []ldap.Group, compute
 func setObjectFields(obj reflect.Value, dn, cn string) {
 	dnField := obj.FieldByName("dn")
 	cnField := obj.FieldByName("cn")
-	reflect.NewAt(dnField.Type(), unsafe.Pointer(dnField.UnsafeAddr())).Elem().SetString(dn) //nolint:gosec
-	reflect.NewAt(cnField.Type(), unsafe.Pointer(cnField.UnsafeAddr())).Elem().SetString(cn) //nolint:gosec
+	// test-only writers for unexported simple-ldap-go fields; never used in production code.
+	dnPtr := unsafe.Pointer(dnField.UnsafeAddr()) //nolint:gosec // test-only DN field write
+	cnPtr := unsafe.Pointer(cnField.UnsafeAddr()) //nolint:gosec // test-only CN field write
+	reflect.NewAt(dnField.Type(), dnPtr).Elem().SetString(dn)
+	reflect.NewAt(cnField.Type(), cnPtr).Elem().SetString(cn)
 }

--- a/internal/ldap_cache/seed_for_tests.go
+++ b/internal/ldap_cache/seed_for_tests.go
@@ -1,0 +1,26 @@
+// Package ldap_cache — seed_for_tests.go: exposes test-only seeding hooks
+// that bypass LDAP I/O. NOT for production use; named with the
+// `ForTesting` suffix per the Go convention so calls stand out at review.
+//
+//nolint:revive // package name intentionally uses underscore
+package ldap_cache
+
+import (
+	ldap "github.com/netresearch/simple-ldap-go"
+)
+
+// SetUsersForTesting replaces the user cache with the given slice. Test
+// code only — production code should use Refresh().
+func (m *Manager) SetUsersForTesting(users []ldap.User) {
+	m.Users.setAll(users)
+}
+
+// SetGroupsForTesting replaces the group cache. See SetUsersForTesting.
+func (m *Manager) SetGroupsForTesting(groups []ldap.Group) {
+	m.Groups.setAll(groups)
+}
+
+// SetComputersForTesting replaces the computer cache. See SetUsersForTesting.
+func (m *Manager) SetComputersForTesting(computers []ldap.Computer) {
+	m.Computers.setAll(computers)
+}

--- a/internal/web/graph_integration_test.go
+++ b/internal/web/graph_integration_test.go
@@ -1,0 +1,53 @@
+// internal/web/graph_integration_test.go — integration tests for
+// /api/graph.json against a real OpenLDAP container. Skipped when no
+// container is reachable on 127.0.0.1:1389.
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netresearch/ldap-manager/internal/ldap_cache"
+)
+
+// TestGraphJSON_IntegrationUserFocus exercises /api/graph.json against a
+// real OpenLDAP container with seeded data, going through the same
+// RequireAuth-protected route the production server registers. testuser1
+// is a member of two seeded groups (admins, developers), so the returned
+// graph should contain at minimum the focus node plus the group edges.
+func TestGraphJSON_IntegrationUserFocus(t *testing.T) {
+	env := skipIfNoLDAP(t)
+	seedLDAPData(t, env)
+
+	app, store := setupLDAPTestApp(t, env)
+	// Refresh the cache after seeding so the user/group data the test
+	// just installed is visible to BuildGraph.
+	app.ldapCache.Refresh()
+
+	cookies := createAuthSession(t, app, store)
+
+	entity := "cn=testuser1,ou=users," + env.baseDN
+	target := "/api/graph.json?entity=" + url.QueryEscape(entity)
+	req := httptest.NewRequestWithContext(context.Background(), "GET", target, http.NoBody)
+	for _, ck := range cookies {
+		req.AddCookie(ck)
+	}
+
+	resp, err := app.fiber.Test(req, -1)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var data ldap_cache.GraphData
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
+
+	require.Equal(t, entity, data.Focus)
+	require.GreaterOrEqual(t, len(data.Nodes), 1, "expected at least one node (the focus)")
+}

--- a/internal/web/graph_v2_handler.go
+++ b/internal/web/graph_v2_handler.go
@@ -21,7 +21,7 @@ import (
 // body to mirror /api/search-index.json.
 func (a *App) handleGraphJSON(c *fiber.Ctx) error {
 	data, status, errMsg := a.buildGraphFromQuery(c)
-	if data == nil {
+	if status != 0 {
 		return c.Status(status).SendString(errMsg)
 	}
 
@@ -44,11 +44,13 @@ func (a *App) handleGraphJSON(c *fiber.Ctx) error {
 }
 
 // buildGraphFromQuery parses ?entity= and ?depth= from c and returns the
-// resulting graph along with the HTTP status the caller should emit when
-// data is nil. On success returns (data, 0, ""). On failure returns
+// resulting graph. The integer return is the HTTP status the caller should
+// emit when the request was rejected; 0 means "no error, render data".
+// On success returns (data, 0, ""). On failure returns
 // (nil, status, message) so the caller can render the response with the
 // project's standard `c.Status(...).SendString(...)` idiom rather than
-// writing the response from inside the helper.
+// writing the response from inside the helper. Callers MUST branch on
+// `status != 0` (not on `data == nil`) so the error path stays explicit.
 func (a *App) buildGraphFromQuery(c *fiber.Ctx) (*ldap_cache.GraphData, int, string) {
 	entity := c.Query("entity")
 	if entity == "" {
@@ -60,11 +62,16 @@ func (a *App) buildGraphFromQuery(c *fiber.Ctx) (*ldap_cache.GraphData, int, str
 
 	depth := 2
 	if raw := c.Query("depth"); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil {
-			depth = n
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			// Fail fast on non-numeric input rather than silently
+			// falling back to the default — matches the "validate
+			// early" rule in internal/CLAUDE.md.
+			return nil, fiber.StatusBadRequest, "invalid depth"
 		}
+		depth = n
 	}
-	// Clamping happens inside BuildGraph.
+	// Clamping of in-range numeric values happens inside BuildGraph.
 
 	data, err := a.ldapCache.BuildGraph(entity, depth)
 	if err != nil {

--- a/internal/web/graph_v2_handler.go
+++ b/internal/web/graph_v2_handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 
 	goldap "github.com/go-ldap/ldap/v3"
@@ -27,18 +26,24 @@ func (a *App) handleGraphJSON(c *fiber.Ctx) error {
 
 	body, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("marshal graph: %w", err)
+		log.Error().
+			Err(err).
+			Str("entity", c.Query("entity")).
+			Msg("graph: marshal failed")
+
+		return c.Status(fiber.StatusInternalServerError).SendString("internal error")
 	}
+
 	sum := sha256.Sum256(body)
 	etag := `"` + hex.EncodeToString(sum[:16]) + `"`
+	c.Set("ETag", etag)
+	c.Set("Cache-Control", "private, must-revalidate")
 
 	if match := c.Get("If-None-Match"); match != "" && match == etag {
 		return c.SendStatus(fiber.StatusNotModified)
 	}
 
 	c.Set("Content-Type", "application/json; charset=utf-8")
-	c.Set("ETag", etag)
-	c.Set("Cache-Control", "private, must-revalidate")
 
 	return c.Send(body)
 }

--- a/internal/web/graph_v2_handler.go
+++ b/internal/web/graph_v2_handler.go
@@ -1,0 +1,90 @@
+// internal/web/graph_v2_handler.go — /graph and /api/graph.json.
+package web
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	goldap "github.com/go-ldap/ldap/v3"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog/log"
+
+	"github.com/netresearch/ldap-manager/internal/ldap_cache"
+)
+
+// handleGraphJSON serves /api/graph.json?entity=<dn>&depth=<N>. Response
+// shape documented in the spec §4.1. ETag is sha256 of the marshalled
+// body to mirror /api/search-index.json.
+func (a *App) handleGraphJSON(c *fiber.Ctx) error {
+	data, status, errMsg := a.buildGraphFromQuery(c)
+	if data == nil {
+		return c.Status(status).SendString(errMsg)
+	}
+
+	body, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal graph: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	etag := `"` + hex.EncodeToString(sum[:16]) + `"`
+
+	if match := c.Get("If-None-Match"); match != "" && match == etag {
+		return c.SendStatus(fiber.StatusNotModified)
+	}
+
+	c.Set("Content-Type", "application/json; charset=utf-8")
+	c.Set("ETag", etag)
+	c.Set("Cache-Control", "private, must-revalidate")
+
+	return c.Send(body)
+}
+
+// buildGraphFromQuery parses ?entity= and ?depth= from c and returns the
+// resulting graph along with the HTTP status the caller should emit when
+// data is nil. On success returns (data, 0, ""). On failure returns
+// (nil, status, message) so the caller can render the response with the
+// project's standard `c.Status(...).SendString(...)` idiom rather than
+// writing the response from inside the helper.
+func (a *App) buildGraphFromQuery(c *fiber.Ctx) (*ldap_cache.GraphData, int, string) {
+	entity := c.Query("entity")
+	if entity == "" {
+		return nil, fiber.StatusBadRequest, "missing entity"
+	}
+	if _, err := goldap.ParseDN(entity); err != nil {
+		return nil, fiber.StatusBadRequest, "invalid DN"
+	}
+
+	depth := 2
+	if raw := c.Query("depth"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			depth = n
+		}
+	}
+	// Clamping happens inside BuildGraph.
+
+	data, err := a.ldapCache.BuildGraph(entity, depth)
+	if err != nil {
+		if errors.Is(err, ldap_cache.ErrGraphNotFound) {
+			return nil, fiber.StatusNotFound, "entity not found"
+		}
+
+		// Log the underlying error with context, but return a generic
+		// message to the client — `err.Error()` may contain DN fragments
+		// or other internals that should not appear in the response body
+		// (see internal/web/CLAUDE.md: "Error responses don't leak
+		// sensitive data").
+		log.Error().
+			Err(err).
+			Str("entity", entity).
+			Int("depth", depth).
+			Msg("BuildGraph failed")
+
+		return nil, fiber.StatusInternalServerError, "internal error"
+	}
+
+	return data, 0, ""
+}

--- a/internal/web/graph_v2_handler_test.go
+++ b/internal/web/graph_v2_handler_test.go
@@ -113,6 +113,28 @@ func TestHandleGraphJSON_ETagStable(t *testing.T) {
 	}
 }
 
+func TestHandleGraphJSON_NotModifiedKeepsHeaders(t *testing.T) {
+	app, _ := setupFullTestApp(t)
+	seedBob(t, app)
+
+	req1 := httptest.NewRequest("GET", "/api/graph.json?entity="+bobDN, nil)
+	resp1, err := app.fiber.Test(req1)
+	require.NoError(t, err)
+	etag := resp1.Header.Get("ETag")
+	_ = resp1.Body.Close()
+	require.NotEmpty(t, etag)
+
+	req2 := httptest.NewRequest("GET", "/api/graph.json?entity="+bobDN, nil)
+	req2.Header.Set("If-None-Match", etag)
+	resp2, err := app.fiber.Test(req2)
+	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
+
+	require.Equal(t, http.StatusNotModified, resp2.StatusCode)
+	require.Equal(t, etag, resp2.Header.Get("ETag"), "304 must echo ETag")
+	require.NotEmpty(t, resp2.Header.Get("Cache-Control"), "304 must keep Cache-Control")
+}
+
 func TestHandleGraphJSON_DepthClamping(t *testing.T) {
 	app, _ := setupFullTestApp(t)
 	seedBob(t, app)

--- a/internal/web/graph_v2_handler_test.go
+++ b/internal/web/graph_v2_handler_test.go
@@ -68,6 +68,19 @@ func TestHandleGraphJSON_UnknownDN(t *testing.T) {
 	}
 }
 
+func TestHandleGraphJSON_InvalidDepth(t *testing.T) {
+	app, _ := setupFullTestApp(t)
+
+	req := httptest.NewRequest("GET", "/api/graph.json?entity="+bobDN+"&depth=abc", nil)
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", resp.StatusCode)
+	}
+}
+
 func TestHandleGraphJSON_ETagStable(t *testing.T) {
 	app, _ := setupFullTestApp(t)
 	seedBob(t, app)

--- a/internal/web/graph_v2_handler_test.go
+++ b/internal/web/graph_v2_handler_test.go
@@ -1,0 +1,132 @@
+// internal/web/graph_v2_handler_test.go — unit tests for /api/graph.json.
+package web
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ldap "github.com/netresearch/simple-ldap-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netresearch/ldap-manager/internal/ldap_cache"
+	"github.com/netresearch/ldap-manager/internal/ldap_cache/cachetest"
+)
+
+// bobDN is the seeded user used by the success-path tests. The handler
+// only reads from app.ldapCache, so it doesn't need to match any session
+// identity.
+const bobDN = "cn=bob,dc=test,dc=local"
+
+// seedBob installs a single user with bobDN into the test app's cache so
+// /api/graph.json?entity=bobDN resolves to a real entity instead of 404.
+func seedBob(t *testing.T, app *App) {
+	t.Helper()
+	cachetest.Seed(app.ldapCache, []ldap.User{
+		cachetest.NewUserWithDN(bobDN, "bob", "bob", true, nil),
+	}, nil, nil)
+}
+
+func TestHandleGraphJSON_MissingEntity(t *testing.T) {
+	app, _ := setupFullTestApp(t)
+
+	req := httptest.NewRequest("GET", "/api/graph.json", nil)
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandleGraphJSON_InvalidDN(t *testing.T) {
+	app, _ := setupFullTestApp(t)
+
+	req := httptest.NewRequest("GET", "/api/graph.json?entity=not~a~dn", nil)
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandleGraphJSON_UnknownDN(t *testing.T) {
+	app, _ := setupFullTestApp(t)
+
+	req := httptest.NewRequest("GET", "/api/graph.json?entity=cn=ghost,dc=ex,dc=com", nil)
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHandleGraphJSON_ETagStable(t *testing.T) {
+	app, _ := setupFullTestApp(t)
+	seedBob(t, app)
+
+	req1 := httptest.NewRequest("GET", "/api/graph.json?entity="+bobDN, nil)
+	resp1, err := app.fiber.Test(req1)
+	require.NoError(t, err)
+
+	if resp1.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp1.Body)
+		_ = resp1.Body.Close()
+		t.Fatalf("first call: got %d, want 200; body=%q", resp1.StatusCode, string(body))
+	}
+
+	etag := resp1.Header.Get("ETag")
+	_ = resp1.Body.Close()
+
+	if etag == "" {
+		t.Fatal("ETag missing on first call")
+	}
+
+	req2 := httptest.NewRequest("GET", "/api/graph.json?entity="+bobDN, nil)
+	req2.Header.Set("If-None-Match", etag)
+	resp2, err := app.fiber.Test(req2)
+	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
+
+	if resp2.StatusCode != http.StatusNotModified {
+		t.Errorf("status: got %d, want 304", resp2.StatusCode)
+	}
+}
+
+func TestHandleGraphJSON_DepthClamping(t *testing.T) {
+	app, _ := setupFullTestApp(t)
+	seedBob(t, app)
+
+	for _, raw := range []string{"0", "99", "-5"} {
+		t.Run("depth="+raw, func(t *testing.T) {
+			url := "/api/graph.json?entity=" + bobDN + "&depth=" + raw
+			req := httptest.NewRequest("GET", url, nil)
+			resp, err := app.fiber.Test(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("depth=%q status: got %d, want 200", raw, resp.StatusCode)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var data ldap_cache.GraphData
+			if err := json.Unmarshal(body, &data); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			if data.Depth < 1 || data.Depth > 3 {
+				t.Errorf("depth=%q returned Depth=%d, expected [1,3]", raw, data.Depth)
+			}
+		})
+	}
+}

--- a/internal/web/ldap_integration_test.go
+++ b/internal/web/ldap_integration_test.go
@@ -216,6 +216,7 @@ func setupLDAPTestApp(t *testing.T, env *ldapIntegrationEnv) (*App, *session.Sto
 	protected.Get("/users/*", app.handleUserV2)
 	protected.Get("/groups/*", app.handleGroupV2)
 	protected.Get("/computers/*", app.handleComputerV2)
+	protected.Get("/api/graph.json", app.handleGraphJSON)
 	protected.Post("/users/*", app.userModifyHandler)
 	protected.Post("/groups/*", app.groupModifyHandler)
 	protected.Get("/logout", app.logoutHandler)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -335,6 +335,10 @@ func (a *App) setupRoutes() {
 	// in-handler so template-cache middleware is not needed.
 	protected.Get("/api/search-index.json", a.handleSearchIndex)
 
+	// Relationship graph JSON (spec §4.1) — same ETag pattern as
+	// /api/search-index.json.
+	protected.Get("/api/graph.json", a.handleGraphJSON)
+
 	// Bulk actions (Phase 3 + 4) — registered BEFORE each /<kind>/* wildcard
 	// POST so Fiber matches the exact /<kind>/bulk path first.
 	protected.Post("/users/bulk", a.handleBulkUsers)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -120,6 +120,12 @@ func setupFullTestApp(t *testing.T) (*App, *session.Store) {
 	// Production wires the same handler inside the protected group (see server.go).
 	f.Get("/api/search-index.json", app.handleSearchIndex)
 
+	// Relationship graph JSON — registered without RequireAuth here for the
+	// same reason as search-index above; production wires it inside the
+	// protected group (see server.go). The handler reads only from
+	// app.ldapCache, so no session state is required.
+	f.Get("/api/graph.json", app.handleGraphJSON)
+
 	protected := f.Group("/", app.RequireAuth())
 	protected.Get("/", app.handleHomeV2)
 	protected.Get("/users", app.templateCacheMiddleware(), app.handleUsersV2)


### PR DESCRIPTION
## Summary

Slice 2 of 6 for the Phase 3 relationship graph view. Adds the JSON endpoint that the upcoming HTML/SVG slices will consume.

Plan: `docs/superpowers/plans/2026-04-24-phase-3-graph-view.md` Tasks 10-14. Slice 1 (the in-memory graph builder) is already on main as #581.

## What ships

- **`GET /api/graph.json?entity=<dn>&depth=<N>`** — registered in `protected` group of `internal/web/server.go`.
- **Validation:** missing entity (400), invalid DN (400), non-numeric depth (400), unknown DN (404).
- **Caching:** sha256-based ETag (matches `/api/search-index.json` pattern); `If-None-Match` short-circuits to 304; `Cache-Control: private, must-revalidate`.
- **Default depth:** 2. Out-of-range integer values (-5, 0, 99) clamp to [1, 3] inside `BuildGraph`.
- **Error hygiene:** 500 returns generic `"internal error"`; underlying error logged via zerolog with `entity` + `depth` context (no DN/internals leakage).

## Test infrastructure changes

To let `internal/web/` tests seed `internal/ldap_cache.Manager` from outside the package:

- **NEW `internal/ldap_cache/cachetest/`** sub-package — exports `NewUserWithDN`, `NewGroupWithDN`, `NewComputerWithDN`, `Seed`. Uses reflection+unsafe to populate the unexported `Object.dn`/`cn` fields on `simple-ldap-go` types. Test-only by convention; not imported by any production code.
- **NEW `internal/ldap_cache/seed_for_tests.go`** — adds `Manager.SetUsersForTesting / SetGroupsForTesting / SetComputersForTesting` exported methods. Thin wrappers around the unexported `setAll`. `ForTesting` suffix per Go convention.

## Tests (7 total, all green)

- `TestHandleGraphJSON_MissingEntity` — 400 on missing `?entity=`.
- `TestHandleGraphJSON_InvalidDN` — 400 on garbage DN.
- `TestHandleGraphJSON_UnknownDN` — 404 when DN not in cache.
- `TestHandleGraphJSON_InvalidDepth` — 400 on non-numeric depth.
- `TestHandleGraphJSON_ETagStable` — first call returns 200+ETag, second with `If-None-Match` returns 304.
- `TestHandleGraphJSON_DepthClamping` — depth=0/99/-5 all return 200 with `Depth ∈ [1,3]`.
- `TestGraphJSON_IntegrationUserFocus` — exercises the full stack against real OpenLDAP (skipped if no container at `127.0.0.1:1389`).

## Test plan

- [x] `go test ./internal/web/ -run TestHandleGraphJSON -count=1 -v` → 6 unit tests PASS
- [x] Integration test PASS against `osixia/openldap:1.5.0` with `dc=test,dc=local`
- [x] `go test ./internal/ldap_cache/... -count=1` → no Slice 1 regression
- [x] `golangci-lint run ./internal/web/... ./internal/ldap_cache/...` → 0 issues
- [x] `go build ./...` clean
- [ ] CI verification on push

## What's next

Slice 3: HTML template + SSR-rendered SVG (no-JS fallback path). Slice 4: interactive canvas. Slices 5-6: list-page mode + drawer pivots + AAA parallel list view + docs.