### PR TITLE
docs(cache): correct remove() complexity comment

### DIFF
--- a/internal/ldap_cache/cache.go
+++ b/internal/ldap_cache/cache.go
@@ -138,9 +138,13 @@ func (c *Cache[T]) update(fn func(*T)) {
 // without waiting for the next background Refresh (which can be delayed
 // by AD replication between the modifying DC and the readonly-bind DC).
 //
-// Uses the dnIndex for O(1) location lookup and slices.Delete for the
-// slice shrink (which zeroes the vacated slot, so pointer fields inside
-// T do not keep the removed entry's data alive indefinitely).
+// The dnIndex provides fast presence detection, but locating the
+// matching slice element still requires a linear scan over c.items
+// (we compare slice-element pointers, not by DN). After deletion we
+// rebuild every index, which is also O(n). Overall removal is O(n).
+// slices.Delete shrinks the slice and zeroes the vacated slot, so
+// pointer fields inside T do not keep the removed entry's data alive
+// indefinitely.
 func (c *Cache[T]) remove(dn string) {
 	c.m.Lock()
 	defer c.m.Unlock()


### PR DESCRIPTION
Follow-up to #579 review feedback.

The doc comment on `Cache[T].remove()` claimed "O(1) location lookup via dnIndex" but the implementation:
1. Uses dnIndex only for **presence** detection (the cached pointer)
2. Then **linearly scans** `c.items` to find the matching slice element by pointer comparison
3. Calls `buildIndexes()` afterwards, which is also O(n)

Comment now reflects the true O(n) complexity. No behavior change.

Resolves the unresolved review thread on #579 (https://github.com/netresearch/ldap-manager/pull/579#discussion_r3140128068).