### PR TITLE
feat(graph): phase 3 graph view — Slice 4 (interactive JS canvas)

### DIFF
--- a/internal/e2e/graph_test.go
+++ b/internal/e2e/graph_test.go
@@ -57,7 +57,11 @@ func TestGraphHappyPath(t *testing.T) {
 	// which is wrong for path segments).
 	dn, err := url.PathUnescape(encodedDN)
 	require.NoError(t, err)
-	require.Contains(t, dn, "dc=test", "expected a test-domain DN")
+	// Don't assume a specific base DN — local dev uses dc=test,dc=local
+	// while CI's e2e fixture uses dc=example,dc=com. Just sanity-check
+	// the shape: it should be a CN under some OU.
+	require.Contains(t, dn, "cn=", "expected a CN-based DN")
+	require.Contains(t, dn, "ou=", "expected the DN to live under an OU")
 
 	// Step 2: direct nav to /graph for that user, depth=2.
 	graphPath := "/graph?entity=" + url.QueryEscape(dn) + "&depth=2"

--- a/internal/e2e/graph_test.go
+++ b/internal/e2e/graph_test.go
@@ -1,0 +1,120 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGraphHappyPath covers the Slice 4 interactive graph flow:
+//  1. Sign in as test user, navigate to /users, pick the first user's DN.
+//  2. Navigate directly to /graph?entity=<dn>&depth=2 (the drawer pivot
+//     that Slice 6 will add isn't shipped yet).
+//  3. Assert the SVG canvas and edge table are present.
+//  4. Assert the inline graph data is parseable.
+//  5. Click an expandable node's badge — assert the aria-live region
+//     announces an "Expanded ..." message.
+//  6. With reduced-motion emulated, repeat the page load — confirm the
+//     same DOM still renders (motion-disable verification proper belongs
+//     in the Slice 6 axe-core ratchet).
+//
+// Plan deviations:
+//   - Slice 6 will add the "View relationships" drawer pivot (Task 35).
+//     Until then we navigate directly to /graph.
+//   - Slice 4 expand updates the SVG only; the edge <table> is SSR-only,
+//     so the plan's "new <tr> appears" assertion is impossible without
+//     a server-side re-render. Skipped.
+func TestGraphHappyPath(t *testing.T) {
+	config := DefaultTestConfig()
+	browser := NewTestBrowser(t, config)
+	defer browser.Close()
+
+	page := browser.NewPage(t)
+	defer page.Close()
+	tp := NewTestPage(t, page, config)
+
+	require.NoError(t, tp.LoginAsTestUser())
+
+	// Step 1: pick the first user from /users.
+	tp.Navigate("/users")
+	require.NoError(t, page.Locator(".list-row__link").First().WaitFor())
+
+	firstRowHref, err := page.Locator(".list-row__link").First().GetAttribute("href")
+	require.NoError(t, err)
+	require.NotEmpty(t, firstRowHref)
+	// firstRowHref looks like "/users/cn%3Dtestuser1%2Cou%3Dusers%2Cdc%3Dtest%2Cdc%3Dlocal".
+	const userPrefix = "/users/"
+	require.True(t, strings.HasPrefix(firstRowHref, userPrefix), "unexpected user href shape: %s", firstRowHref)
+	encodedDN := strings.TrimPrefix(firstRowHref, userPrefix)
+	dn, err := url.QueryUnescape(encodedDN)
+	require.NoError(t, err)
+	require.Contains(t, dn, "dc=test", "expected a test-domain DN")
+
+	// Step 2: direct nav to /graph for that user, depth=2.
+	graphPath := "/graph?entity=" + url.QueryEscape(dn) + "&depth=2"
+	tp.Navigate(graphPath)
+
+	// Step 3: SVG canvas + table present.
+	require.NoError(t, page.Locator("svg#graph-canvas").WaitFor())
+	require.NoError(t, page.Locator("table.graph-table").WaitFor())
+
+	// Step 4: inline graph-data template parses.
+	dataLen, err := page.Evaluate(`() => {
+		const el = document.getElementById('graph-data');
+		if (!el || !el.content) return -1;
+		try {
+			return JSON.parse(el.content.textContent).nodes.length;
+		} catch (e) {
+			return -2;
+		}
+	}`)
+	require.NoError(t, err)
+	// playwright-go transports JS numbers as int when integral.
+	dataLenInt, ok := dataLen.(int)
+	require.True(t, ok, "expected int from page.Evaluate, got %T (%v)", dataLen, dataLen)
+	assert.Greater(t, dataLenInt, 0, "graph-data should contain at least the focus node")
+
+	// Step 5: click an expandable node and watch the aria-live region.
+	// First, wait for v2-graph.js to have activated nodes (added tabindex).
+	require.NoError(t, page.Locator(".graph-node[tabindex='0']").First().WaitFor())
+
+	// Look for an expandable node with a badge.
+	badgeLocator := page.Locator(".graph-node[data-expandable='true'] .graph-node__expand-badge").First()
+	badgeCount, err := badgeLocator.Count()
+	require.NoError(t, err)
+	if badgeCount > 0 {
+		require.NoError(t, badgeLocator.Click())
+		// Aria-live region should pick up an "Expanded" announcement.
+		require.NoError(t, page.Locator("#graph-announce").WaitFor())
+		// Wait briefly for fetch + announce.
+		_, err = page.WaitForFunction(`() => {
+			const el = document.getElementById('graph-announce');
+			return el && el.textContent.indexOf('Expanded') !== -1;
+		}`, nil)
+		require.NoError(t, err, "expected aria-live region to announce expansion")
+	} else {
+		t.Log("no expandable node visible — graph topology has no further hops; skipping expand assertion")
+	}
+
+	// Step 6: reduced-motion render. The CSS already disables graph
+	// transitions when prefers-reduced-motion is set; the JS doesn't
+	// add any. We just confirm the same selectors still resolve under
+	// the reduced-motion media query.
+	rmPage := browser.NewPage(t)
+	defer rmPage.Close()
+	require.NoError(t, rmPage.EmulateMedia(playwright.PageEmulateMediaOptions{
+		ReducedMotion: playwright.ReducedMotionReduce,
+	}))
+
+	rmTP := NewTestPage(t, rmPage, config)
+	require.NoError(t, rmTP.LoginAsTestUser())
+	rmTP.Navigate(graphPath)
+	require.NoError(t, rmPage.Locator("svg#graph-canvas").WaitFor())
+	require.NoError(t, rmPage.Locator("table.graph-table").WaitFor())
+}

--- a/internal/e2e/graph_test.go
+++ b/internal/e2e/graph_test.go
@@ -82,9 +82,19 @@ func TestGraphHappyPath(t *testing.T) {
 		}
 	}`)
 	require.NoError(t, err)
-	// playwright-go transports JS numbers as int when integral.
-	dataLenInt, ok := dataLen.(int)
-	require.True(t, ok, "expected int from page.Evaluate, got %T (%v)", dataLen, dataLen)
+	// playwright-go's JSON transport unmarshals numbers as float64 by
+	// default, but accept int/int64 too to stay robust across versions.
+	var dataLenInt int
+	switch v := dataLen.(type) {
+	case int:
+		dataLenInt = v
+	case int64:
+		dataLenInt = int(v)
+	case float64:
+		dataLenInt = int(v)
+	default:
+		t.Fatalf("expected numeric from page.Evaluate, got %T (%v)", dataLen, dataLen)
+	}
 	assert.Greater(t, dataLenInt, 0, "graph-data should contain at least the focus node")
 
 	// Step 5: click an expandable node and watch the aria-live region.

--- a/internal/e2e/graph_test.go
+++ b/internal/e2e/graph_test.go
@@ -52,7 +52,10 @@ func TestGraphHappyPath(t *testing.T) {
 	const userPrefix = "/users/"
 	require.True(t, strings.HasPrefix(firstRowHref, userPrefix), "unexpected user href shape: %s", firstRowHref)
 	encodedDN := strings.TrimPrefix(firstRowHref, userPrefix)
-	dn, err := url.QueryUnescape(encodedDN)
+	// userDetailHref emits paths via url.PathEscape; decode with the
+	// matching PathUnescape (QueryUnescape would convert '+' to space,
+	// which is wrong for path segments).
+	dn, err := url.PathUnescape(encodedDN)
 	require.NoError(t, err)
 	require.Contains(t, dn, "dc=test", "expected a test-domain DN")
 

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -32,6 +32,25 @@
     }
   }
 
+  // nodeLabel mirrors graphNodeLabel() in graph_v2.templ so screen-reader
+  // labels for nodes added via expandNode() carry the same type/state
+  // context as SSR-rendered nodes.
+  function nodeLabel(n) {
+    switch (n.type) {
+      case "group":
+        var count = typeof n.memberCount === "number" ? n.memberCount : 0;
+        return "Group " + n.label + " (" + count + " members).";
+      case "user":
+        var state = n.enabled === false ? "disabled" : "enabled";
+        return "User " + n.label + " (" + state + ").";
+      case "computer":
+        return "Computer " + n.label + ".";
+      case "ou":
+        return "Organisational unit " + n.label + ".";
+    }
+    return n.label;
+  }
+
   // activateNodes makes each rendered .graph-node keyboard-focusable
   // and properly labelled now that the JS handlers exist. Slice 3
   // deliberately omitted these attributes from the SSR template.
@@ -42,8 +61,15 @@
       n.setAttribute("role", "button");
       var label = n.getAttribute("aria-label") || "";
       if (label && label.indexOf("Press Enter to open.") === -1) {
-        n.setAttribute("aria-label", label + " Press Enter to open.");
+        label = label + " Press Enter to open.";
       }
+      if (
+        n.getAttribute("data-expandable") === "true" &&
+        label.indexOf("Press + to expand") === -1
+      ) {
+        label = label + " Press + to expand more relations.";
+      }
+      n.setAttribute("aria-label", label);
     });
   }
 
@@ -57,7 +83,6 @@
 
     activateNodes(svg);
     wirePanZoom(svg, viewport);
-    wireKeyboardNav(svg);
     wireNodeClicks(svg, state);
     wireDepthSlider();
   });
@@ -78,15 +103,11 @@
     }
 
     svg.addEventListener("mousedown", function (e) {
-      // Only start panning when the user grabs empty canvas space
-      // (the SVG itself or the viewport <g>) — not when they click a
-      // node or edge.
-      if (
-        e.target !== svg &&
-        !e.target.classList.contains("graph-viewport")
-      ) {
-        return;
-      }
+      // Allow pan-start anywhere except on a node — clicks on edges or
+      // empty canvas both pan. Dense graphs leave little empty space, so
+      // restricting pan to the SVG/viewport background made it hard to
+      // grab.
+      if (e.target.closest(".graph-node")) return;
       dragging = true;
       sx = e.clientX - tx;
       sy = e.clientY - ty;
@@ -103,14 +124,24 @@
     });
 
     // Wheel zoom only when modifier key is held — without ctrl/meta the
-    // page scroll behaviour is preserved.
+    // page scroll behaviour is preserved. Zoom around the cursor so the
+    // world-space point under the pointer stays put after the scale
+    // change (standard map/graph UX).
     svg.addEventListener(
       "wheel",
       function (e) {
         if (!(e.ctrlKey || e.metaKey)) return;
         e.preventDefault();
+        var rect = svg.getBoundingClientRect();
+        var cx = e.clientX - rect.left;
+        var cy = e.clientY - rect.top;
+        var oldScale = scale;
         var delta = -e.deltaY * 0.001;
         scale = Math.min(3, Math.max(0.3, scale * (1 + delta)));
+        if (oldScale !== scale) {
+          tx = cx - ((cx - tx) * scale) / oldScale;
+          ty = cy - ((cy - ty) * scale) / oldScale;
+        }
         apply();
       },
       { passive: false },
@@ -156,31 +187,7 @@
       }
     });
   }
-  function wireKeyboardNav(svg) {
-    // Snapshot the node list at wire time. Nodes added later by
-    // expandNode (Task 26) won't join this cycle until the user
-    // navigates back to the graph; that's an acceptable tradeoff to
-    // keep this handler stateless.
-    var nodes = Array.prototype.slice.call(
-      svg.querySelectorAll(".graph-node"),
-    );
-    var index = 0;
-    function focusAt(i) {
-      if (nodes.length === 0) return;
-      index = ((i % nodes.length) + nodes.length) % nodes.length;
-      nodes[index].focus();
-    }
-    svg.addEventListener("keydown", function (e) {
-      if (!e.target.classList.contains("graph-node")) return;
-      if (e.key === "Tab" && !e.shiftKey) {
-        focusAt(index + 1);
-        e.preventDefault();
-      } else if (e.key === "Tab" && e.shiftKey) {
-        focusAt(index - 1);
-        e.preventDefault();
-      }
-    });
-  }
+
   function wireNodeClicks(svg, state) {
     svg.addEventListener("click", function (e) {
       var node = e.target.closest(".graph-node");
@@ -196,16 +203,24 @@
         pivotToDrawer(dn, type);
       }
     });
+    // Keyboard parity with mouse: Enter pivots (matches the SSR
+    // aria-label "Press Enter to open"), and +/= expands when the node
+    // is expandable. Space is intentionally not bound — convention on
+    // non-form elements is page-down, not activation.
     svg.addEventListener("keydown", function (e) {
-      if (e.key !== "Enter" && e.key !== " ") return;
       var node = e.target.closest(".graph-node");
       if (!node) return;
       var dn = node.getAttribute("data-dn");
       var type = node.getAttribute("data-type");
       var expandable = node.getAttribute("data-expandable") === "true";
-      e.preventDefault();
-      if (expandable) expandNode(dn, state, svg);
-      else pivotToDrawer(dn, type);
+
+      if (e.key === "Enter") {
+        e.preventDefault();
+        pivotToDrawer(dn, type);
+      } else if (expandable && (e.key === "+" || e.key === "=")) {
+        e.preventDefault();
+        expandNode(dn, state, svg);
+      }
     });
   }
 
@@ -248,6 +263,7 @@
       .then(function (data) {
         var added = 0;
         var existingDNs = {};
+        var affectedRings = {};
         state.nodes.forEach(function (n) {
           existingDNs[n.dn] = true;
         });
@@ -259,6 +275,7 @@
           n.ring = (parent && parent.ring + 1) || 2;
           state.nodes.push(n);
           renderNode(svg, n);
+          affectedRings[n.ring] = true;
           added++;
         });
         data.edges.forEach(function (e) {
@@ -273,6 +290,14 @@
             state.edges.push(e);
             renderEdge(svg, e, state.nodes);
           }
+        });
+        // Re-distribute angles on each ring that gained a node. Without
+        // this, expanded nodes keep the angles the backend assigned in
+        // the depth=1 ego graph (centred on the clicked node) — which
+        // were computed for a different node set and overlap or cluster
+        // oddly when merged into the original layout.
+        Object.keys(affectedRings).forEach(function (r) {
+          reLayoutRing(svg, state, parseInt(r, 10));
         });
         // Mark clicked node as non-expandable so a subsequent click
         // pivots to the drawer instead of re-fetching.
@@ -292,6 +317,59 @@
         console.error("graph expand failed", err);
         announce("Expand failed.");
       });
+  }
+
+  // reLayoutRing redistributes nodes on a ring evenly around the circle
+  // and re-routes any edges touching them. Called after expandNode
+  // merges new nodes onto an existing ring.
+  function reLayoutRing(svg, state, ring) {
+    var ringNodes = state.nodes.filter(function (n) {
+      return n.ring === ring;
+    });
+    ringNodes.sort(function (a, b) {
+      if (a.type !== b.type) return a.type < b.type ? -1 : 1;
+      if (a.label !== b.label) return a.label < b.label ? -1 : 1;
+      return a.dn < b.dn ? -1 : 1;
+    });
+    var count = ringNodes.length;
+    if (count === 0) return;
+    ringNodes.forEach(function (n, i) {
+      n.angle = (i * 2 * Math.PI) / count;
+      var r = ring * 150;
+      var x = r * Math.cos(n.angle);
+      var y = r * Math.sin(n.angle);
+      var el = svg.querySelector(
+        '.graph-node[data-dn="' + CSS.escape(n.dn) + '"]',
+      );
+      if (el) el.setAttribute("transform", "translate(" + x + "," + y + ")");
+    });
+    // Re-route edges touching any moved node on this ring.
+    state.edges.forEach(function (e) {
+      var src = state.nodes.find(function (x) {
+        return x.dn === e.source;
+      });
+      var tgt = state.nodes.find(function (x) {
+        return x.dn === e.target;
+      });
+      if (!src || !tgt) return;
+      if (src.ring !== ring && tgt.ring !== ring) return;
+      var line = svg.querySelector(
+        'line[data-source="' +
+          CSS.escape(e.source) +
+          '"][data-target="' +
+          CSS.escape(e.target) +
+          '"]',
+      );
+      if (!line) return;
+      var sx = src.ring * 150 * Math.cos(src.angle);
+      var sy = src.ring * 150 * Math.sin(src.angle);
+      var tx = tgt.ring * 150 * Math.cos(tgt.angle);
+      var ty = tgt.ring * 150 * Math.sin(tgt.angle);
+      line.setAttribute("x1", sx);
+      line.setAttribute("y1", sy);
+      line.setAttribute("x2", tx);
+      line.setAttribute("y2", ty);
+    });
   }
 
   function renderNode(svg, n) {
@@ -314,12 +392,13 @@
     g.setAttribute("data-dn", n.dn);
     g.setAttribute("data-type", n.type);
     g.setAttribute("data-expandable", String(!!n.expandable));
-    // Match activateNodes() so newly inserted nodes get the same
-    // accessible affordance the SSR-rendered ones receive.
-    g.setAttribute(
-      "aria-label",
-      (n.label || n.dn) + ". Press Enter to open.",
-    );
+    // Mirror activateNodes(): build the same "<typed label>. Press
+    // Enter to open. [Press + to expand more relations.]" hint stack
+    // so newly inserted nodes carry full screen-reader context.
+    var base = nodeLabel(n);
+    var hint = " Press Enter to open.";
+    if (n.expandable) hint += " Press + to expand more relations.";
+    g.setAttribute("aria-label", base + hint);
     var circ = document.createElementNS(ns, "circle");
     circ.setAttribute("r", "28");
     circ.setAttribute("class", "graph-node__disc");

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -62,8 +62,99 @@
     wireDepthSlider();
   });
 
-  function wirePanZoom(_svg, _viewport) {
-    /* Task 24 */
+  function wirePanZoom(svg, viewport) {
+    var tx = 0,
+      ty = 0,
+      scale = 1;
+    var dragging = false,
+      sx = 0,
+      sy = 0;
+
+    function apply() {
+      viewport.setAttribute(
+        "transform",
+        "translate(" + tx + "," + ty + ") scale(" + scale + ")",
+      );
+    }
+
+    svg.addEventListener("mousedown", function (e) {
+      // Only start panning when the user grabs empty canvas space
+      // (the SVG itself or the viewport <g>) — not when they click a
+      // node or edge.
+      if (
+        e.target !== svg &&
+        !e.target.classList.contains("graph-viewport")
+      ) {
+        return;
+      }
+      dragging = true;
+      sx = e.clientX - tx;
+      sy = e.clientY - ty;
+      e.preventDefault();
+    });
+    window.addEventListener("mousemove", function (e) {
+      if (!dragging) return;
+      tx = e.clientX - sx;
+      ty = e.clientY - sy;
+      apply();
+    });
+    window.addEventListener("mouseup", function () {
+      dragging = false;
+    });
+
+    // Wheel zoom only when modifier key is held — without ctrl/meta the
+    // page scroll behaviour is preserved.
+    svg.addEventListener(
+      "wheel",
+      function (e) {
+        if (!(e.ctrlKey || e.metaKey)) return;
+        e.preventDefault();
+        var delta = -e.deltaY * 0.001;
+        scale = Math.min(3, Math.max(0.3, scale * (1 + delta)));
+        apply();
+      },
+      { passive: false },
+    );
+
+    // Arrow-key pan and +/- zoom when the canvas itself is focused
+    // (the SVG element has tabindex="0" from the SSR template).
+    svg.addEventListener("keydown", function (e) {
+      var step = 32;
+      switch (e.key) {
+        case "ArrowLeft":
+          tx += step;
+          apply();
+          e.preventDefault();
+          break;
+        case "ArrowRight":
+          tx -= step;
+          apply();
+          e.preventDefault();
+          break;
+        case "ArrowUp":
+          ty += step;
+          apply();
+          e.preventDefault();
+          break;
+        case "ArrowDown":
+          ty -= step;
+          apply();
+          e.preventDefault();
+          break;
+        case "+":
+        case "=":
+          scale = Math.min(3, scale * 1.1);
+          apply();
+          e.preventDefault();
+          break;
+        case "-":
+        case "_":
+          scale = Math.max(0.3, scale / 1.1);
+          apply();
+          e.preventDefault();
+          break;
+      }
+    });
   }
   function wireKeyboardNav(_svg) {
     /* Task 25 */

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -347,6 +347,19 @@
     viewport.insertBefore(line, viewport.firstChild);
   }
   function wireDepthSlider() {
-    /* Task 27 */
+    var slider = document.querySelector("[data-graph-slider]");
+    if (!slider) return;
+    var out = document.querySelector(".graph-slider__value");
+    // 'input' fires per-step while the user drags; 'change' fires on
+    // release. Use 'input' for the live value display and 'change' to
+    // submit the form, so a drag from 1→3 produces one navigation,
+    // not three.
+    slider.addEventListener("input", function () {
+      if (out) out.textContent = slider.value;
+    });
+    slider.addEventListener("change", function () {
+      var form = slider.form;
+      if (form) form.submit();
+    });
   }
 })();

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -238,6 +238,11 @@
       "/api/graph.json?entity=" + encodeURIComponent(dn) + "&depth=1";
     fetch(url, { credentials: "same-origin" })
       .then(function (r) {
+        // Surface non-2xx (401 redirect to login, 404 missing entity,
+        // 500 server error) as thrown errors so the .catch below can
+        // announce them — otherwise r.json() would parse the HTML
+        // error body and throw a confusing SyntaxError instead.
+        if (!r.ok) throw new Error("graph expand HTTP " + r.status);
         return r.json();
       })
       .then(function (data) {
@@ -280,6 +285,12 @@
           if (badge) badge.remove();
         }
         announce("Expanded " + dn + ": added " + added + " nodes.");
+      })
+      .catch(function (err) {
+        // Without this the badge stays clickable forever and SR users
+        // hear nothing. Trace + announce so the operator can retry.
+        console.error("graph expand failed", err);
+        announce("Expand failed.");
       });
   }
 
@@ -319,6 +330,27 @@
     text.setAttribute("class", "graph-node__label");
     text.textContent = n.label;
     g.appendChild(text);
+    // Mirror the SSR template's expand-badge (graph_v2.templ graphNode):
+    // without it, freshly-fetched expandable children can be pivoted but
+    // never further expanded by mouse — wireNodeClicks requires a click
+    // on .graph-node__expand-badge to trigger expansion.
+    if (n.expandable) {
+      var badge = document.createElementNS(ns, "g");
+      badge.setAttribute("class", "graph-node__expand-badge");
+      badge.setAttribute("transform", "translate(18,-18)");
+      badge.setAttribute("aria-hidden", "true");
+      var bbg = document.createElementNS(ns, "circle");
+      bbg.setAttribute("r", "8");
+      bbg.setAttribute("class", "graph-node__expand-badge-bg");
+      badge.appendChild(bbg);
+      var bmark = document.createElementNS(ns, "text");
+      bmark.setAttribute("text-anchor", "middle");
+      bmark.setAttribute("y", "3");
+      bmark.setAttribute("class", "graph-node__expand-badge-mark");
+      bmark.textContent = "+";
+      badge.appendChild(bmark);
+      g.appendChild(badge);
+    }
     viewport.appendChild(g);
   }
 

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -181,8 +181,170 @@
       }
     });
   }
-  function wireNodeClicks(_svg, _state) {
-    /* Task 26 */
+  function wireNodeClicks(svg, state) {
+    svg.addEventListener("click", function (e) {
+      var node = e.target.closest(".graph-node");
+      if (!node) return;
+      var dn = node.getAttribute("data-dn");
+      var type = node.getAttribute("data-type");
+      var expandable = node.getAttribute("data-expandable") === "true";
+      var clickedBadge = !!e.target.closest(".graph-node__expand-badge");
+
+      if (expandable && clickedBadge) {
+        expandNode(dn, state, svg);
+      } else {
+        pivotToDrawer(dn, type);
+      }
+    });
+    svg.addEventListener("keydown", function (e) {
+      if (e.key !== "Enter" && e.key !== " ") return;
+      var node = e.target.closest(".graph-node");
+      if (!node) return;
+      var dn = node.getAttribute("data-dn");
+      var type = node.getAttribute("data-type");
+      var expandable = node.getAttribute("data-expandable") === "true";
+      e.preventDefault();
+      if (expandable) expandNode(dn, state, svg);
+      else pivotToDrawer(dn, type);
+    });
+  }
+
+  function pivotToDrawer(dn, type) {
+    var base = {
+      user: "/users/",
+      group: "/groups/",
+      computer: "/computers/",
+      ou: "/users?ou=",
+    }[type];
+    if (!base) return;
+    window.location.href = base + encodeURIComponent(dn);
+  }
+
+  // announce updates the off-screen aria-live region so SR users hear
+  // expansion results. Clear-then-set forces re-announcement when the
+  // same message fires twice.
+  function announce(msg) {
+    var el = document.getElementById("graph-announce");
+    if (el) {
+      el.textContent = "";
+      setTimeout(function () {
+        el.textContent = msg;
+      }, 10);
+    }
+  }
+
+  function expandNode(dn, state, svg) {
+    var url =
+      "/api/graph.json?entity=" + encodeURIComponent(dn) + "&depth=1";
+    fetch(url, { credentials: "same-origin" })
+      .then(function (r) {
+        return r.json();
+      })
+      .then(function (data) {
+        var added = 0;
+        var existingDNs = {};
+        state.nodes.forEach(function (n) {
+          existingDNs[n.dn] = true;
+        });
+        data.nodes.forEach(function (n) {
+          if (existingDNs[n.dn]) return;
+          var parent = state.nodes.find(function (x) {
+            return x.dn === dn;
+          });
+          n.ring = (parent && parent.ring + 1) || 2;
+          state.nodes.push(n);
+          renderNode(svg, n);
+          added++;
+        });
+        data.edges.forEach(function (e) {
+          var dup = state.edges.some(function (x) {
+            return (
+              x.source === e.source &&
+              x.target === e.target &&
+              x.kind === e.kind
+            );
+          });
+          if (!dup) {
+            state.edges.push(e);
+            renderEdge(svg, e, state.nodes);
+          }
+        });
+        // Mark clicked node as non-expandable so a subsequent click
+        // pivots to the drawer instead of re-fetching.
+        var el = svg.querySelector(
+          '.graph-node[data-dn="' + CSS.escape(dn) + '"]',
+        );
+        if (el) {
+          el.setAttribute("data-expandable", "false");
+          var badge = el.querySelector(".graph-node__expand-badge");
+          if (badge) badge.remove();
+        }
+        announce("Expanded " + dn + ": added " + added + " nodes.");
+      });
+  }
+
+  function renderNode(svg, n) {
+    var ns = "http://www.w3.org/2000/svg";
+    var viewport = svg.querySelector(".graph-viewport");
+    // Match the SSR concentricXY radius multiplier (graph_v2.templ
+    // uses 150 so ring-3 nodes — including the 28-radius disc and
+    // expand-badge — fit inside the ±500 viewBox).
+    var r = n.ring * 150;
+    var x = r * Math.cos(n.angle),
+      y = r * Math.sin(n.angle);
+    var g = document.createElementNS(ns, "g");
+    g.setAttribute(
+      "class",
+      "graph-node graph-node--" + n.type + " graph-node--added",
+    );
+    g.setAttribute("transform", "translate(" + x + "," + y + ")");
+    g.setAttribute("tabindex", "0");
+    g.setAttribute("role", "button");
+    g.setAttribute("data-dn", n.dn);
+    g.setAttribute("data-type", n.type);
+    g.setAttribute("data-expandable", String(!!n.expandable));
+    // Match activateNodes() so newly inserted nodes get the same
+    // accessible affordance the SSR-rendered ones receive.
+    g.setAttribute(
+      "aria-label",
+      (n.label || n.dn) + ". Press Enter to open.",
+    );
+    var circ = document.createElementNS(ns, "circle");
+    circ.setAttribute("r", "28");
+    circ.setAttribute("class", "graph-node__disc");
+    g.appendChild(circ);
+    var text = document.createElementNS(ns, "text");
+    text.setAttribute("text-anchor", "middle");
+    text.setAttribute("y", "4");
+    text.setAttribute("class", "graph-node__label");
+    text.textContent = n.label;
+    g.appendChild(text);
+    viewport.appendChild(g);
+  }
+
+  function renderEdge(svg, e, nodes) {
+    var ns = "http://www.w3.org/2000/svg";
+    var viewport = svg.querySelector(".graph-viewport");
+    function xy(dn) {
+      var n = nodes.find(function (x) {
+        return x.dn === dn;
+      });
+      if (!n) return [0, 0];
+      var r = n.ring * 150;
+      return [r * Math.cos(n.angle), r * Math.sin(n.angle)];
+    }
+    var s = xy(e.source),
+      t = xy(e.target);
+    var line = document.createElementNS(ns, "line");
+    line.setAttribute("class", "graph-edge graph-edge--" + e.kind);
+    line.setAttribute("x1", s[0]);
+    line.setAttribute("y1", s[1]);
+    line.setAttribute("x2", t[0]);
+    line.setAttribute("y2", t[1]);
+    line.setAttribute("data-source", e.source);
+    line.setAttribute("data-target", e.target);
+    // Insert at the front so the edge sits behind nodes in z-order.
+    viewport.insertBefore(line, viewport.firstChild);
   }
   function wireDepthSlider() {
     /* Task 27 */

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -156,8 +156,30 @@
       }
     });
   }
-  function wireKeyboardNav(_svg) {
-    /* Task 25 */
+  function wireKeyboardNav(svg) {
+    // Snapshot the node list at wire time. Nodes added later by
+    // expandNode (Task 26) won't join this cycle until the user
+    // navigates back to the graph; that's an acceptable tradeoff to
+    // keep this handler stateless.
+    var nodes = Array.prototype.slice.call(
+      svg.querySelectorAll(".graph-node"),
+    );
+    var index = 0;
+    function focusAt(i) {
+      if (nodes.length === 0) return;
+      index = ((i % nodes.length) + nodes.length) % nodes.length;
+      nodes[index].focus();
+    }
+    svg.addEventListener("keydown", function (e) {
+      if (!e.target.classList.contains("graph-node")) return;
+      if (e.key === "Tab" && !e.shiftKey) {
+        focusAt(index + 1);
+        e.preventDefault();
+      } else if (e.key === "Tab" && e.shiftKey) {
+        focusAt(index - 1);
+        e.preventDefault();
+      }
+    });
   }
   function wireNodeClicks(_svg, _state) {
     /* Task 26 */

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -1,0 +1,77 @@
+/*
+ * v2-graph.js — Phase 3 graph view client. Reads JSON embedded by the
+ * template, enhances the SVG with pan/zoom/keyboard nav and click-to-
+ * pivot/expand. CSP-safe (no eval, no inline scripts, no Function).
+ *
+ * The data island is a <template id="graph-data"> (HTML data island,
+ * inert under script-src 'self'); its content lives in a separate
+ * DocumentFragment so we read it via .content.textContent rather than
+ * .textContent.
+ *
+ * Slice 3 intentionally rendered nodes without role/tabindex/aria
+ * affordances so the SSR markup didn't advertise interactivity it
+ * couldn't provide. Slice 4 (this file) re-adds them via JS once the
+ * handlers are wired up.
+ */
+(function () {
+  "use strict";
+  if (!document.getElementById("graph-data")) return;
+
+  function parseData() {
+    var el = document.getElementById("graph-data");
+    if (!el) return null;
+    try {
+      // <template> content lives in a separate DocumentFragment.
+      // Slice 3 chose <template> over <script type="application/json">
+      // for CSP-safety under script-src 'self'.
+      var text = el.content ? el.content.textContent : el.textContent;
+      return JSON.parse(text);
+    } catch (e) {
+      console.error("graph-data JSON parse failed", e);
+      return null;
+    }
+  }
+
+  // activateNodes makes each rendered .graph-node keyboard-focusable
+  // and properly labelled now that the JS handlers exist. Slice 3
+  // deliberately omitted these attributes from the SSR template.
+  function activateNodes(svg) {
+    var nodes = svg.querySelectorAll(".graph-node");
+    nodes.forEach(function (n) {
+      n.setAttribute("tabindex", "0");
+      n.setAttribute("role", "button");
+      var label = n.getAttribute("aria-label") || "";
+      if (label && label.indexOf("Press Enter to open.") === -1) {
+        n.setAttribute("aria-label", label + " Press Enter to open.");
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var state = parseData();
+    if (!state) return;
+    var svg = document.getElementById("graph-canvas");
+    if (!svg) return;
+    var viewport = svg.querySelector(".graph-viewport");
+    if (!viewport) return;
+
+    activateNodes(svg);
+    wirePanZoom(svg, viewport);
+    wireKeyboardNav(svg);
+    wireNodeClicks(svg, state);
+    wireDepthSlider();
+  });
+
+  function wirePanZoom(_svg, _viewport) {
+    /* Task 24 */
+  }
+  function wireKeyboardNav(_svg) {
+    /* Task 25 */
+  }
+  function wireNodeClicks(_svg, _state) {
+    /* Task 26 */
+  }
+  function wireDepthSlider() {
+    /* Task 27 */
+  }
+})();

--- a/internal/web/templates/base_v2.templ
+++ b/internal/web/templates/base_v2.templ
@@ -47,6 +47,7 @@ templ baseV2Shell(title string, pageScroll bool) {
 			<script defer src="/static/js/v2-drawer.js"></script>
 			<script defer src="/static/js/v2-bulk.js"></script>
 			<script defer src="/static/js/v2-search-filter.js"></script>
+			<script defer src="/static/js/v2-graph.js"></script>
 		</body>
 	</html>
 }


### PR DESCRIPTION
## Summary

Slice 4 of 6 for the Phase 3 relationship graph view. Adds the client-side JS layer that turns Slice 3's SSR view into an interactive canvas (pan/zoom/keyboard nav/click-to-expand) without breaking the no-JS fallback.

Plan: `docs/superpowers/plans/2026-04-24-phase-3-graph-view.md` Tasks 23-29. Slices 1-3 already on main as #581 / #582 / #584.

## What ships

- **`internal/web/static/js/v2-graph.js`** (~290 lines, IIFE, plain JS, CSP-safe) — pan/zoom (mouse drag, wheel+ctrl/meta, arrow keys, +/-), keyboard nav (Tab/Shift-Tab cycles nodes), click-to-pivot (node body → drawer route), click-to-expand (`+` badge → fetch `/api/graph.json?depth=1`, merge nodes/edges, announce via aria-live), depth slider auto-submit on change.
- **Activates SVG nodes for interactivity** at runtime (re-adds `tabindex`, `role="button"`, "Press Enter to open" suffix that Slice 3 deliberately dropped because there was no JS handler then).
- **Reads inline graph data from Slice 3's `<template id="graph-data">`** via `template.content.textContent` — works under strict `script-src 'self'` CSP.
- **Renders dynamically added expandable nodes with their `+` badge** so they're discoverable with the mouse, not just the keyboard.
- **Handles fetch errors gracefully** — bad responses get logged + announced "Expand failed." rather than silently no-op.
- Script wired in `base_v2.templ` head with `defer`; bails immediately on pages without `#graph-data`.
- **`internal/e2e/graph_test.go`** — Playwright happy-path: login → /users → grab DN → /graph?entity=…&depth=2 → assert SVG + table + parseable inline data → click expandable badge → assert aria-live announces → reduced-motion repeat.

## Notable design decisions

- **No build step, no transpilation, no module system** — matches `v2-bulk.js` / `v2-drawer.js` precedent. IIFE wrapper, `'use strict'`, `var` (not `let`/`const`), `function ()` callbacks (no arrows).
- **Ring multiplier 150** in `renderNode`/`renderEdge` matches Slice 3's SSR `concentricXY` so dynamically-added nodes line up with SSR-positioned ones.
- **`CSS.escape(dn)` before selector use** — DNs contain commas/equals that would break attribute selectors.
- **`fetch` with `credentials: 'same-origin'`** — required for the session-authed endpoint.
- **Reduced-motion: nothing extra in JS** — the CSS already disables transitions; JS doesn't introduce new ones.

## Tests

- Existing Slice 1-3 unit tests still pass.
- `TestGraphHappyPath` (Playwright, behind `//go:build e2e`) — runs in CI.

## Test plan

- [x] `go build ./...` — clean
- [x] `go build -tags e2e ./internal/e2e/...` — clean
- [x] `go test ./internal/web/ ./internal/ldap_cache/...` — pass, no regressions
- [x] `golangci-lint run ./...` — 0 issues
- [x] `node -c internal/web/static/js/v2-graph.js` — clean syntax
- [ ] CI verification on push (unit + e2e)
- [ ] Visual smoke (after merge): browse to `/graph?entity=<DN>` and try drag, ctrl+wheel zoom, Tab between nodes, click `+` badge to expand

## What's next

- **Slice 5:** list-page Graph mode (`/users?view=graph`, `/groups?view=graph`, `/computers?view=graph`) — Tasks 30-34.
- **Slice 6:** drawer "View relationships" pivot, axe-core E2E ratchet, README conformance statement — Tasks 35-40.