### PR TITLE
feat(graph): phase 3 graph view — Slice 5 (list-page Graph mode)

### DIFF
--- a/internal/ldap_cache/graph.go
+++ b/internal/ldap_cache/graph.go
@@ -150,16 +150,7 @@ func (m *Manager) BuildListGraph(filtered []ldap.User, filteredComputers []ldap.
 			seen[u.DN()] = 2
 		}
 
-		for _, gDN := range u.Groups {
-			if g, ok := m.Groups.FindByDN(gDN); ok {
-				if _, dup := seen[gDN]; !dup {
-					data.Nodes = append(data.Nodes, groupNode(*g, 1, false))
-					seen[gDN] = 1
-				}
-
-				data.Edges = append(data.Edges, Edge{Source: u.DN(), Target: gDN, Kind: EdgeMemberOf})
-			}
-		}
+		m.addListGroupMemberships(data, seen, u.DN(), u.Groups)
 	}
 
 	for _, c := range filteredComputers {
@@ -168,22 +159,36 @@ func (m *Manager) BuildListGraph(filtered []ldap.User, filteredComputers []ldap.
 			seen[c.DN()] = 2
 		}
 
-		for _, gDN := range c.Groups {
-			if g, ok := m.Groups.FindByDN(gDN); ok {
-				if _, dup := seen[gDN]; !dup {
-					data.Nodes = append(data.Nodes, groupNode(*g, 1, false))
-					seen[gDN] = 1
-				}
-
-				data.Edges = append(data.Edges, Edge{Source: c.DN(), Target: gDN, Kind: EdgeMemberOf})
-			}
-		}
+		m.addListGroupMemberships(data, seen, c.DN(), c.Groups)
 	}
 
 	applyCaps(data)
 	assignConcentric(data)
 
 	return data
+}
+
+// addListGroupMemberships adds ring-1 group nodes for each groupDN in
+// memberGroups (resolving via the cache; missing groups are skipped) and
+// a deduped memberOf edge from sourceDN. Used by BuildListGraph for both
+// users and computers — same shape, different source type.
+func (m *Manager) addListGroupMemberships(data *GraphData, seen map[string]int, sourceDN string, memberGroups []string) {
+	for _, gDN := range memberGroups {
+		g, ok := m.Groups.FindByDN(gDN)
+		if !ok {
+			continue
+		}
+
+		if _, dup := seen[gDN]; !dup {
+			data.Nodes = append(data.Nodes, groupNode(*g, 1, false))
+			seen[gDN] = 1
+		}
+
+		edge := Edge{Source: sourceDN, Target: gDN, Kind: EdgeMemberOf}
+		if !hasEdge(data, edge) {
+			data.Edges = append(data.Edges, edge)
+		}
+	}
 }
 
 func (m *Manager) buildGraphFromGroup(g ldap.Group, depth int) *GraphData {

--- a/internal/ldap_cache/graph.go
+++ b/internal/ldap_cache/graph.go
@@ -136,6 +136,56 @@ func (m *Manager) BuildGraph(focusDN string, depth int) (*GraphData, error) {
 	return nil, fmt.Errorf("%w: %q", ErrGraphNotFound, focusDN)
 }
 
+// BuildListGraph builds a graph for list-page mode: the filtered set
+// plus each member's direct groups. Focus is "" (no single focal entity)
+// and no node has ring 0. Users/computers live in ring 2; groups in
+// ring 1. Used by /users?view=graph, /groups?view=graph, /computers?view=graph.
+func (m *Manager) BuildListGraph(filtered []ldap.User, filteredComputers []ldap.Computer) *GraphData {
+	data := &GraphData{Focus: "", Depth: 1}
+	seen := map[string]int{}
+
+	for _, u := range filtered {
+		if _, dup := seen[u.DN()]; !dup {
+			data.Nodes = append(data.Nodes, userNode(u, 2, false))
+			seen[u.DN()] = 2
+		}
+
+		for _, gDN := range u.Groups {
+			if g, ok := m.Groups.FindByDN(gDN); ok {
+				if _, dup := seen[gDN]; !dup {
+					data.Nodes = append(data.Nodes, groupNode(*g, 1, false))
+					seen[gDN] = 1
+				}
+
+				data.Edges = append(data.Edges, Edge{Source: u.DN(), Target: gDN, Kind: EdgeMemberOf})
+			}
+		}
+	}
+
+	for _, c := range filteredComputers {
+		if _, dup := seen[c.DN()]; !dup {
+			data.Nodes = append(data.Nodes, computerNode(c, 2))
+			seen[c.DN()] = 2
+		}
+
+		for _, gDN := range c.Groups {
+			if g, ok := m.Groups.FindByDN(gDN); ok {
+				if _, dup := seen[gDN]; !dup {
+					data.Nodes = append(data.Nodes, groupNode(*g, 1, false))
+					seen[gDN] = 1
+				}
+
+				data.Edges = append(data.Edges, Edge{Source: c.DN(), Target: gDN, Kind: EdgeMemberOf})
+			}
+		}
+	}
+
+	applyCaps(data)
+	assignConcentric(data)
+
+	return data
+}
+
 func (m *Manager) buildGraphFromGroup(g ldap.Group, depth int) *GraphData {
 	data := &GraphData{Focus: g.DN(), Depth: depth}
 	data.Nodes = append(data.Nodes, groupNode(g, 0, false))

--- a/internal/ldap_cache/graph_test.go
+++ b/internal/ldap_cache/graph_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -397,6 +398,46 @@ func TestBuildGraph_OUFocus_EscapedCommaChild(t *testing.T) {
 
 	if !foundEdge {
 		t.Errorf("escaped-comma immediate child %q must have contains edge from %q", childDN, ouDN)
+	}
+}
+
+func TestBuildListGraph_FilteredUsers(t *testing.T) {
+	m := graphFixture(t)
+	filtered := m.Users.Filter(func(u ldap.User) bool {
+		return strings.Contains(u.DN(), "ou=Engineering")
+	})
+	data := m.BuildListGraph(filtered, nil)
+
+	if data.Focus != "" {
+		t.Errorf("Focus should be empty for list mode, got %q", data.Focus)
+	}
+
+	if data.Depth != 1 {
+		t.Errorf("Depth should be 1 for list mode, got %d", data.Depth)
+	}
+
+	// graphFixture has bob/dave/alice under ou=Engineering (3 immediate)
+	// PLUS deep under ou=Nested,ou=Engineering (1 nested descendant) = 4 users.
+	// Their groups: bob→admins+engineers, dave→engineers, alice→engineers,
+	// deep→none. So unique groups = admins, engineers (all-staff is NOT
+	// pulled in — bob is not directly a member of all-staff).
+	// Expected: 4 users + 2 groups = 6 nodes.
+	if got := len(data.Nodes); got != 6 {
+		t.Errorf("node count: got %d, want 6", got)
+	}
+
+	// Every user-→group edge should be EdgeMemberOf with source = user DN.
+	for _, e := range data.Edges {
+		if e.Kind != EdgeMemberOf {
+			t.Errorf("edge kind: got %q, want %q for %+v", e.Kind, EdgeMemberOf, e)
+		}
+	}
+
+	// No ring-0 node in list mode.
+	for _, n := range data.Nodes {
+		if n.Ring == 0 {
+			t.Errorf("list mode should have no ring-0 node, got %+v", n)
+		}
 	}
 }
 

--- a/internal/web/computers_v2_handler.go
+++ b/internal/web/computers_v2_handler.go
@@ -85,9 +85,14 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 
 	sortComputersByCN(computers)
 
-	if c.Query("view") == "graph" && a.ldapCache != nil {
+	currentView := c.Query("view")
+	if a.ldapCache == nil {
+		currentView = ""
+	}
+
+	if currentView == "graph" && a.ldapCache != nil {
 		data := a.ldapCache.BuildListGraph(nil, computers)
-		vm := templates.GraphPageVM{Data: data}
+		vm := templates.GraphPageVM{Data: data, BackHref: "/computers", FocusLabel: "Computers"}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
 	}
@@ -96,7 +101,7 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-	return templates.ComputersListV2(computers, ouFilter, ous, a.takeFlash(c), a.paletteContextFor(viewerDN), c.Query("view")).
+	return templates.ComputersListV2(computers, ouFilter, ous, a.takeFlash(c), a.paletteContextFor(viewerDN), currentView).
 		Render(c.UserContext(), c.Response().BodyWriter())
 }
 

--- a/internal/web/computers_v2_handler.go
+++ b/internal/web/computers_v2_handler.go
@@ -85,6 +85,13 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 
 	sortComputersByCN(computers)
 
+	if c.Query("view") == "graph" && a.ldapCache != nil {
+		data := a.ldapCache.BuildListGraph(nil, computers)
+		vm := templates.GraphPageVM{Data: data}
+
+		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
+	}
+
 	ous := distinctImmediateOUsFromComputers(all)
 
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)

--- a/internal/web/computers_v2_handler.go
+++ b/internal/web/computers_v2_handler.go
@@ -96,7 +96,7 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-	return templates.ComputersListV2(computers, ouFilter, ous, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+	return templates.ComputersListV2(computers, ouFilter, ous, a.takeFlash(c), a.paletteContextFor(viewerDN), c.Query("view")).
 		Render(c.UserContext(), c.Response().BodyWriter())
 }
 

--- a/internal/web/graph_v2_handler_test.go
+++ b/internal/web/graph_v2_handler_test.go
@@ -235,3 +235,81 @@ func TestHandleGraphV2_RendersHTML(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleGroupsV2_GraphMode(t *testing.T) {
+	app, store := setupFullTestApp(t)
+	cookies := createAuthSession(t, app, store)
+
+	// Seed a group with bob as a member; the handler walks Members
+	// and looks each DN up in Users/Computers caches.
+	const engineersDN = "cn=engineers,ou=Groups,dc=test,dc=local"
+	cachetest.Seed(app.ldapCache,
+		[]ldap.User{
+			cachetest.NewUserWithDN(bobDN, "bob", "bob", true, []string{engineersDN}),
+		},
+		[]ldap.Group{
+			cachetest.NewGroupWithDN(engineersDN, "engineers", []string{bobDN}),
+		},
+		nil,
+	)
+
+	req := httptest.NewRequest("GET", "/groups?view=graph", nil)
+	for _, ck := range cookies {
+		req.AddCookie(ck)
+	}
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	html := string(body)
+
+	for _, marker := range []string{`id="graph-canvas"`, `id="graph-data"`, `class="graph-table"`} {
+		if !strings.Contains(html, marker) {
+			t.Errorf("missing HTML marker %q", marker)
+		}
+	}
+	// Member-lookup regression check: bob should appear in the graph
+	// data because the groups handler walks Members and resolves them.
+	require.Contains(t, html, "bob", "expected the looked-up member to appear in the rendered graph")
+}
+
+func TestHandleComputersV2_GraphMode(t *testing.T) {
+	app, store := setupFullTestApp(t)
+	cookies := createAuthSession(t, app, store)
+
+	const ws01DN = "cn=ws01,ou=Computers,dc=test,dc=local"
+	const engineersDN = "cn=engineers,ou=Groups,dc=test,dc=local"
+	cachetest.Seed(app.ldapCache,
+		nil,
+		[]ldap.Group{
+			cachetest.NewGroupWithDN(engineersDN, "engineers", []string{ws01DN}),
+		},
+		[]ldap.Computer{
+			cachetest.NewComputerWithDN(ws01DN, "ws01", "ws01$", true, []string{engineersDN}),
+		},
+	)
+
+	req := httptest.NewRequest("GET", "/computers?view=graph", nil)
+	for _, ck := range cookies {
+		req.AddCookie(ck)
+	}
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	html := string(body)
+
+	for _, marker := range []string{`id="graph-canvas"`, `id="graph-data"`, `class="graph-table"`, "ws01"} {
+		if !strings.Contains(html, marker) {
+			t.Errorf("missing HTML marker %q", marker)
+		}
+	}
+}

--- a/internal/web/graph_v2_handler_test.go
+++ b/internal/web/graph_v2_handler_test.go
@@ -167,6 +167,48 @@ func TestHandleGraphJSON_DepthClamping(t *testing.T) {
 	}
 }
 
+func TestHandleUsersV2_GraphMode(t *testing.T) {
+	app, store := setupFullTestApp(t)
+	// Seed bob with one group membership so BuildListGraph has both
+	// a user (ring 2) and a group (ring 1).
+	cachetest.Seed(app.ldapCache,
+		[]ldap.User{
+			cachetest.NewUserWithDN(bobDN, "bob", "bob", true, []string{
+				"cn=engineers,ou=Groups,dc=test,dc=local",
+			}),
+		},
+		[]ldap.Group{
+			cachetest.NewGroupWithDN("cn=engineers,ou=Groups,dc=test,dc=local", "engineers", []string{bobDN}),
+		},
+		nil,
+	)
+
+	cookies := createAuthSession(t, app, store)
+	req := httptest.NewRequest("GET", "/users?view=graph", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	html := string(body)
+
+	for _, marker := range []string{
+		`id="graph-canvas"`,
+		`id="graph-data"`,
+		`class="graph-table"`,
+	} {
+		if !strings.Contains(html, marker) {
+			t.Errorf("missing HTML marker %q in /users?view=graph response", marker)
+		}
+	}
+}
+
 func TestHandleGraphV2_RendersHTML(t *testing.T) {
 	app, _ := setupFullTestApp(t)
 	seedBob(t, app)

--- a/internal/web/groups_v2_handler.go
+++ b/internal/web/groups_v2_handler.go
@@ -296,21 +296,30 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 	groups = filterGroupsByMember(groups, memberDN)
 	sortGroupsByCN(groups)
 
-	if c.Query("view") == "graph" && a.ldapCache != nil {
+	currentView := c.Query("view")
+	if a.ldapCache == nil {
+		currentView = ""
+	}
+
+	if currentView == "graph" && a.ldapCache != nil {
 		members := make([]ldap.User, 0)
 		computers := make([]ldap.Computer, 0)
+		seenMember := make(map[string]struct{})
 		for _, g := range groups {
 			for _, mDN := range g.Members {
+				if _, dup := seenMember[mDN]; dup {
+					continue
+				}
+				seenMember[mDN] = struct{}{}
 				if u, ok := a.ldapCache.Users.FindByDN(mDN); ok {
 					members = append(members, *u)
-				}
-				if comp, ok := a.ldapCache.Computers.FindByDN(mDN); ok {
+				} else if comp, ok := a.ldapCache.Computers.FindByDN(mDN); ok {
 					computers = append(computers, *comp)
 				}
 			}
 		}
 		data := a.ldapCache.BuildListGraph(members, computers)
-		vm := templates.GraphPageVM{Data: data}
+		vm := templates.GraphPageVM{Data: data, BackHref: "/groups", FocusLabel: "Groups"}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
 	}
@@ -319,7 +328,7 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-	return templates.GroupsListV2(groups, ouFilter, memberDN, memberCN, ous, a.takeFlash(c), a.paletteContextFor(viewerDN), c.Query("view")).
+	return templates.GroupsListV2(groups, ouFilter, memberDN, memberCN, ous, a.takeFlash(c), a.paletteContextFor(viewerDN), currentView).
 		Render(c.UserContext(), c.Response().BodyWriter())
 }
 

--- a/internal/web/groups_v2_handler.go
+++ b/internal/web/groups_v2_handler.go
@@ -296,6 +296,25 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 	groups = filterGroupsByMember(groups, memberDN)
 	sortGroupsByCN(groups)
 
+	if c.Query("view") == "graph" && a.ldapCache != nil {
+		members := make([]ldap.User, 0)
+		computers := make([]ldap.Computer, 0)
+		for _, g := range groups {
+			for _, mDN := range g.Members {
+				if u, ok := a.ldapCache.Users.FindByDN(mDN); ok {
+					members = append(members, *u)
+				}
+				if comp, ok := a.ldapCache.Computers.FindByDN(mDN); ok {
+					computers = append(computers, *comp)
+				}
+			}
+		}
+		data := a.ldapCache.BuildListGraph(members, computers)
+		vm := templates.GraphPageVM{Data: data}
+
+		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
+	}
+
 	memberCN := lookupUserCN(memberDN, a.ldapCache)
 
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)

--- a/internal/web/groups_v2_handler.go
+++ b/internal/web/groups_v2_handler.go
@@ -319,7 +319,7 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-	return templates.GroupsListV2(groups, ouFilter, memberDN, memberCN, ous, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+	return templates.GroupsListV2(groups, ouFilter, memberDN, memberCN, ous, a.takeFlash(c), a.paletteContextFor(viewerDN), c.Query("view")).
 		Render(c.UserContext(), c.Response().BodyWriter())
 }
 

--- a/internal/web/static/app.css
+++ b/internal/web/static/app.css
@@ -2716,3 +2716,9 @@ button.kv-edit__save {
 @media (prefers-reduced-motion: reduce) {
   .graph-node, .graph-edge { transition: none !important; }
 }
+
+.graph-segmented { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; overflow: hidden; }
+.graph-segmented__option { padding: 0.4rem 1rem; color: var(--fg-muted); text-decoration: none; }
+.graph-segmented__option:hover { background: var(--bg-subtle); }
+.graph-segmented__option--active { background: var(--accent); color: var(--bg); }
+.graph-segmented__option:focus-visible { outline: 2px solid var(--border-strong); outline-offset: 2px; }

--- a/internal/web/static/app.css
+++ b/internal/web/static/app.css
@@ -2717,8 +2717,10 @@ button.kv-edit__save {
   .graph-node, .graph-edge { transition: none !important; }
 }
 
-.graph-segmented { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; overflow: hidden; }
+.graph-segmented { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; }
 .graph-segmented__option { padding: 0.4rem 1rem; color: var(--fg-muted); text-decoration: none; }
+.graph-segmented__option:first-child { border-top-left-radius: 999px; border-bottom-left-radius: 999px; }
+.graph-segmented__option:last-child { border-top-right-radius: 999px; border-bottom-right-radius: 999px; }
 .graph-segmented__option:hover { background: var(--bg-subtle); }
 .graph-segmented__option--active { background: var(--accent); color: var(--bg); }
 .graph-segmented__option:focus-visible { outline: 2px solid var(--border-strong); outline-offset: 2px; }

--- a/internal/web/templates/computers_v2.templ
+++ b/internal/web/templates/computers_v2.templ
@@ -22,7 +22,7 @@ type ComputerDrawerVM struct {
 	IsAD        bool   // true when backend is Active Directory — gates the Disable button (which also requires Computer.Enabled)
 }
 
-templ ComputersListV2(computers []ldap.Computer, ouFilter string, ous []string, flashes []Flash, palettePinned []PinnedEntry) {
+templ ComputersListV2(computers []ldap.Computer, ouFilter string, ous []string, flashes []Flash, palettePinned []PinnedEntry, currentView string) {
 	@baseV2("Computers") {
 		@topnavV2("/computers")
 
@@ -30,6 +30,7 @@ templ ComputersListV2(computers []ldap.Computer, ouFilter string, ous []string, 
 			<header class="list-page__head">
 				<h1 class="list-page__title">Computers</h1>
 				<p class="list-page__count">{ fmt.Sprintf("%d", len(computers)) } computers</p>
+				@listGraphToggle("/computers", currentView, computersFilterQS(ouFilter))
 			</header>
 
 			@listFlashes(flashes)
@@ -380,6 +381,19 @@ func computerDrawerFragmentHref(cp ldap.Computer) string {
 
 func clearComputersOUHref() templ.SafeURL {
 	return templ.URL("/computers")
+}
+
+// computersFilterQS encodes the active /computers filter combination as a
+// bare query string (no leading "?", no view selector). Used by the
+// listGraphToggle to preserve filters when switching between
+// list / graph segments.
+func computersFilterQS(ouFilter string) string {
+	v := url.Values{}
+	if ouFilter != "" {
+		v.Set("ou", ouFilter)
+	}
+
+	return v.Encode()
 }
 
 // computerOUHref maps an OU value to a /computers URL for the OU rail. An

--- a/internal/web/templates/graph_toggle.templ
+++ b/internal/web/templates/graph_toggle.templ
@@ -1,0 +1,65 @@
+// internal/web/templates/graph_toggle.templ — segmented "List | Graph"
+// view toggle reused by all three list pages (Phase 3 §6.6).
+package templates
+
+import "strings"
+
+// listGraphToggle renders the segmented control. `base` is the bare list
+// route ("/users", "/groups", "/computers"). `currentView` is the value
+// of c.Query("view") at request time (empty string for default list).
+// `filters` is the URL-encoded query string of OTHER filters to preserve
+// (without leading "?", without view=…). Both branches preserve filters.
+templ listGraphToggle(base, currentView, filters string) {
+	<nav class="graph-segmented" role="group" aria-label="List or graph view">
+		<a
+			class={ "graph-segmented__option", toggleClass(currentView, "") }
+			href={ templ.URL(buildToggleHref(base, "", filters)) }
+			aria-pressed={ toggleAriaPressed(currentView, "") }
+		>List</a>
+		<a
+			class={ "graph-segmented__option", toggleClass(currentView, "graph") }
+			href={ templ.URL(buildToggleHref(base, "graph", filters)) }
+			aria-pressed={ toggleAriaPressed(currentView, "graph") }
+		>Graph</a>
+	</nav>
+}
+
+// toggleClass returns the active modifier class when the segment matches
+// the current view; otherwise an empty string (templ filters out empties
+// from the multi-arg class attribute).
+func toggleClass(current, target string) string {
+	if current == target {
+		return "graph-segmented__option--active"
+	}
+
+	return ""
+}
+
+// toggleAriaPressed mirrors toggleClass for the aria-pressed attribute so
+// assistive tech announces which segment is currently selected.
+func toggleAriaPressed(current, target string) string {
+	if current == target {
+		return "true"
+	}
+
+	return "false"
+}
+
+// buildToggleHref combines base path + view selector + preserved filters.
+// "view=graph" goes first when set; other filter pairs follow.
+func buildToggleHref(base, view, filters string) string {
+	parts := []string{}
+	if view != "" {
+		parts = append(parts, "view="+view)
+	}
+
+	if filters != "" {
+		parts = append(parts, filters)
+	}
+
+	if len(parts) == 0 {
+		return base
+	}
+
+	return base + "?" + strings.Join(parts, "&")
+}

--- a/internal/web/templates/graph_toggle.templ
+++ b/internal/web/templates/graph_toggle.templ
@@ -10,16 +10,16 @@ import "strings"
 // `filters` is the URL-encoded query string of OTHER filters to preserve
 // (without leading "?", without view=…). Both branches preserve filters.
 templ listGraphToggle(base, currentView, filters string) {
-	<nav class="graph-segmented" role="group" aria-label="List or graph view">
+	<nav class="graph-segmented" aria-label="List or graph view">
 		<a
 			class={ "graph-segmented__option", toggleClass(currentView, "") }
 			href={ templ.URL(buildToggleHref(base, "", filters)) }
-			aria-pressed={ toggleAriaPressed(currentView, "") }
+			aria-current={ toggleAriaCurrent(currentView, "") }
 		>List</a>
 		<a
 			class={ "graph-segmented__option", toggleClass(currentView, "graph") }
 			href={ templ.URL(buildToggleHref(base, "graph", filters)) }
-			aria-pressed={ toggleAriaPressed(currentView, "graph") }
+			aria-current={ toggleAriaCurrent(currentView, "graph") }
 		>Graph</a>
 	</nav>
 }
@@ -35,11 +35,15 @@ func toggleClass(current, target string) string {
 	return ""
 }
 
-// toggleAriaPressed mirrors toggleClass for the aria-pressed attribute so
-// assistive tech announces which segment is currently selected.
-func toggleAriaPressed(current, target string) string {
+// toggleAriaCurrent returns "page" when the link points at the active
+// view, "false" otherwise. aria-current is the WAI-ARIA attribute for
+// links representing the current location (aria-pressed is reserved for
+// role="button"). Per WAI-ARIA 1.2, aria-current="false" is the explicit
+// "not current" value, equivalent to omitting the attribute — we render
+// it explicitly to keep templ's positional attribute output predictable.
+func toggleAriaCurrent(current, target string) string {
 	if current == target {
-		return "true"
+		return "page"
 	}
 
 	return "false"

--- a/internal/web/templates/graph_v2.templ
+++ b/internal/web/templates/graph_v2.templ
@@ -39,6 +39,9 @@ templ GraphPageV2(vm GraphPageVM) {
 		<main id="main-content" class="graph-page">
 			<header class="graph-page__head">
 				<h1 class="graph-page__title">{ graphTitle(vm) }</h1>
+				if vm.BackHref != "" {
+					@listGraphToggle(vm.BackHref, "graph", "")
+				}
 				@graphDepthSlider(vm.Data.Depth, vm.Data.Focus)
 			</header>
 			if vm.Data.Overflow.Truncated {

--- a/internal/web/templates/groups_v2.templ
+++ b/internal/web/templates/groups_v2.templ
@@ -31,7 +31,7 @@ type GroupDrawerVM struct {
 	FlashError        string       // set by modify handlers when an LDAP op fails; shown inline
 }
 
-templ GroupsListV2(groups []ldap.Group, ouFilter, memberDN, memberCN string, ous []string, flashes []Flash, palettePinned []PinnedEntry) {
+templ GroupsListV2(groups []ldap.Group, ouFilter, memberDN, memberCN string, ous []string, flashes []Flash, palettePinned []PinnedEntry, currentView string) {
 	@baseV2("Groups") {
 		@topnavV2("/groups")
 
@@ -39,6 +39,7 @@ templ GroupsListV2(groups []ldap.Group, ouFilter, memberDN, memberCN string, ous
 			<header class="list-page__head">
 				<h1 class="list-page__title">Groups</h1>
 				<p class="list-page__count">{ fmt.Sprintf("%d", len(groups)) } groups</p>
+				@listGraphToggle("/groups", currentView, groupsFilterQS(ouFilter, memberDN))
 			</header>
 
 			@listFlashes(flashes)
@@ -637,6 +638,23 @@ templ groupAddUserForm(vm GroupDrawerVM) {
 			</button>
 		</form>
 	}
+}
+
+// groupsFilterQS encodes the active /groups filter combination as a bare
+// query string (no leading "?", no view selector). Used by the
+// listGraphToggle to preserve filters when switching between
+// list / graph segments.
+func groupsFilterQS(ouFilter, memberDN string) string {
+	v := url.Values{}
+	if ouFilter != "" {
+		v.Set("ou", ouFilter)
+	}
+
+	if memberDN != "" {
+		v.Set("member", memberDN)
+	}
+
+	return v.Encode()
 }
 
 // groupsFilterHref composes a /groups URL combining the OU and member

--- a/internal/web/templates/users_v2.templ
+++ b/internal/web/templates/users_v2.templ
@@ -29,7 +29,7 @@ type UserDrawerVM struct {
 	IsAD             bool         // true when the backend is Active Directory — gates the Disable button (which also requires User.Enabled) since OpenLDAP has no portable disable mechanism
 }
 
-templ UsersListV2(users []ldap.User, showDisabled bool, ouFilter string, lastLogon string, memberOfDN, memberOfCN string, ous []string, flashes []Flash, palettePinned []PinnedEntry, adminDNs map[string]struct{}) {
+templ UsersListV2(users []ldap.User, showDisabled bool, ouFilter string, lastLogon string, memberOfDN, memberOfCN string, ous []string, flashes []Flash, palettePinned []PinnedEntry, adminDNs map[string]struct{}, currentView string) {
 	@baseV2("Users") {
 		@topnavV2("/users")
 
@@ -37,6 +37,7 @@ templ UsersListV2(users []ldap.User, showDisabled bool, ouFilter string, lastLog
 			<header class="list-page__head">
 				<h1 class="list-page__title">Users</h1>
 				<p class="list-page__count">{ fmt.Sprintf("%d", len(users)) } users</p>
+				@listGraphToggle("/users", currentView, usersFilterQS(showDisabled, ouFilter, lastLogon, memberOfDN))
 			</header>
 
 			@listFlashes(flashes)
@@ -735,6 +736,31 @@ func userOUHrefFactory(showDisabled bool, lastLogon, memberOfDN string) ouHref {
 	return func(value string) templ.SafeURL {
 		return usersFilterHref(showDisabled, value, lastLogon, memberOfDN)
 	}
+}
+
+// usersFilterQS encodes the active /users filter combination as a bare
+// query string (no leading "?", no view selector). Used by the
+// listGraphToggle to preserve filters when switching between
+// list / graph segments.
+func usersFilterQS(showDisabled bool, ouFilter, lastLogon, memberOfDN string) string {
+	v := url.Values{}
+	if showDisabled {
+		v.Set("show-disabled", "1")
+	}
+
+	if ouFilter != "" {
+		v.Set("ou", ouFilter)
+	}
+
+	if lastLogon != "" {
+		v.Set("last-logon", lastLogon)
+	}
+
+	if memberOfDN != "" {
+		v.Set("memberOf", memberOfDN)
+	}
+
+	return v.Encode()
 }
 
 // usersFilterHref composes a /users URL with the supplied combination of

--- a/internal/web/users_v2_handler.go
+++ b/internal/web/users_v2_handler.go
@@ -102,6 +102,13 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 	users = filterUsersByMemberOf(users, memberOf, a.ldapCache)
 	sortUsersByCN(users)
 
+	if c.Query("view") == "graph" && a.ldapCache != nil {
+		data := a.ldapCache.BuildListGraph(users, nil)
+		vm := templates.GraphPageVM{Data: data}
+
+		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
+	}
+
 	memberOfCN := lookupGroupCN(memberOf, a.ldapCache)
 	adminDNs := adminUserDNs(a.ldapCache)
 

--- a/internal/web/users_v2_handler.go
+++ b/internal/web/users_v2_handler.go
@@ -118,7 +118,7 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 		users, showDisabled, ouFilter, lastLogon,
 		memberOf, memberOfCN, ous,
 		a.takeFlash(c), a.paletteContextFor(viewerDN),
-		adminDNs,
+		adminDNs, c.Query("view"),
 	)
 
 	return page.Render(c.UserContext(), c.Response().BodyWriter())

--- a/internal/web/users_v2_handler.go
+++ b/internal/web/users_v2_handler.go
@@ -102,9 +102,14 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 	users = filterUsersByMemberOf(users, memberOf, a.ldapCache)
 	sortUsersByCN(users)
 
-	if c.Query("view") == "graph" && a.ldapCache != nil {
+	currentView := c.Query("view")
+	if a.ldapCache == nil {
+		currentView = ""
+	}
+
+	if currentView == "graph" && a.ldapCache != nil {
 		data := a.ldapCache.BuildListGraph(users, nil)
-		vm := templates.GraphPageVM{Data: data}
+		vm := templates.GraphPageVM{Data: data, BackHref: "/users", FocusLabel: "Users"}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
 	}
@@ -118,7 +123,7 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 		users, showDisabled, ouFilter, lastLogon,
 		memberOf, memberOfCN, ous,
 		a.takeFlash(c), a.paletteContextFor(viewerDN),
-		adminDNs, c.Query("view"),
+		adminDNs, currentView,
 	)
 
 	return page.Render(c.UserContext(), c.Response().BodyWriter())


### PR DESCRIPTION
## Summary

Slice 5 of 6 for the Phase 3 relationship graph view. Adds the list-page Graph mode: `/users?view=graph`, `/groups?view=graph`, `/computers?view=graph`, with a "List | Graph" segmented toggle on each page.

Plan: `docs/superpowers/plans/2026-04-24-phase-3-graph-view.md` Tasks 30-34. Slices 1-4 already on main.

## What ships

- **`(*Manager).BuildListGraph(filtered []ldap.User, filteredComputers []ldap.Computer) *GraphData`** — new builder for list-page mode. Focus is empty (no ring-0 node). Users/computers go on ring 2; their direct groups on ring 1. Reuses `applyCaps` + `assignConcentric`.
- **`?view=graph` branch** in all three list handlers (users/groups/computers). Reuses each handler's existing filter+sort pipeline so the graph view consumes exactly the same dataset list view would render.
  - Users: `BuildListGraph(users, nil)`.
  - Groups: walks each filtered group's `Members`, looks up DNs in both Users + Computers caches, calls `BuildListGraph(members, computers)`.
  - Computers: `BuildListGraph(nil, computers)`.
- **`listGraphToggle` segmented control** — new `internal/web/templates/graph_toggle.templ` shared component. Renders inside each list page's `<header class="list-page__head">`. Preserves existing filter query-params across view switches via per-page `*FilterQS` helper.
- **A11y:** uses `aria-current="page"` for the active option (correct pattern for navigation links — `aria-pressed` is for toggle buttons). `<nav aria-label="List or graph view">` provides the navigation landmark without doubling via `role="group"`.
- **CSS:** 5 segmented-control rules — pill-shape inline-flex, `:hover`, `:focus-visible`, `--option--active` using existing `--accent`/`--bg` tokens (already AAA-verified by Slice 3's contrast test).

## Tests

- `TestBuildListGraph_FilteredUsers` — Engineering users → 4 users + 2 groups = 6 nodes; no ring-0; all edges memberOf.
- `TestHandleUsersV2_GraphMode`, `TestHandleGroupsV2_GraphMode`, `TestHandleComputersV2_GraphMode` — render tests for each handler's `?view=graph` branch. Groups test asserts member-lookup actually surfaces the seeded user in the rendered graph (catches regression in the Members→Users fan-out).
- All Slice 1-4 tests still pass.

## Test plan

- [x] `go build ./...` — clean
- [x] `go build -tags e2e ./internal/e2e/...` — clean
- [x] `go test ./internal/web/ ./internal/web/templates/ ./internal/ldap_cache/` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI verification on push
- [ ] Visual smoke (after merge): browse to `/users`, click "Graph" toggle, verify the SVG renders with users/groups/edges and the toggle preserves filters across `?ou=…` etc.

## What's next

- **Slice 6:** drawer "View relationships" pivot (so users can launch the graph view from a user/group/computer detail drawer), axe-core E2E ratchet, README conformance statement. Tasks 35-40.