### PR TITLE
feat(graph): phase 3 graph view — Slice 6 (drawer pivots + axe ratchet + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ LDAP Manager's login page conforms to [WCAG 2.2](https://www.w3.org/TR/WCAG22/) 
 
 Conformance is enforced in CI by a contrast unit test (`internal/web/contrast_test.go`) and an axe-core AAA pass on every E2E run (`internal/e2e/axe_test.go`). Additional routes will be brought under the same guarantee as they migrate in subsequent slices.
 
+The relationship graph view at `/graph` (and the `List | Graph` mode toggle on the user, group, and computer list pages) meets WCAG 2.2 Level AA. An equivalent flat edge table is always rendered below the visual canvas, providing an AAA-equivalent text alternative for every interaction and relationship the canvas displays. The graph pages are covered by the same axe-core ratchet (`internal/e2e/axe_graph_test.go`).
+
 ## Contributing
 
 Contributions welcome! Please open a Pull Request.

--- a/internal/e2e/axe_graph_test.go
+++ b/internal/e2e/axe_graph_test.go
@@ -1,0 +1,107 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAxeAAA_GraphPages asserts the Phase 3 graph view pages have zero
+// WCAG violations under the same axe-core ruleset used by the login
+// page test. Covers:
+//   - /graph?entity=<seeded-DN>&depth=2 (entity-focused mode)
+//   - /users?view=graph                 (list-page Graph mode)
+//   - /groups?view=graph
+//   - /computers?view=graph
+//
+// Authenticated as the test user; uses the first user from /users to
+// pick a real DN for the entity-focused page (matches the existing
+// graph_test.go pattern).
+func TestAxeAAA_GraphPages(t *testing.T) {
+	config := DefaultTestConfig()
+	browser := NewTestBrowser(t, config)
+	defer browser.Close()
+
+	page := browser.NewPage(t)
+	defer page.Close()
+	tp := NewTestPage(t, page, config)
+
+	require.NoError(t, tp.LoginAsTestUser())
+
+	// Discover a real seeded user DN by visiting /users and reading the
+	// first row's href (mirrors graph_test.go).
+	tp.Navigate("/users")
+	require.NoError(t, page.Locator(".list-row__link").First().WaitFor())
+
+	firstRowHref, err := page.Locator(".list-row__link").First().GetAttribute("href")
+	require.NoError(t, err)
+	require.NotEmpty(t, firstRowHref)
+	require.True(t, strings.HasPrefix(firstRowHref, "/users/"), "unexpected href: %s", firstRowHref)
+	dn, err := url.PathUnescape(strings.TrimPrefix(firstRowHref, "/users/"))
+	require.NoError(t, err)
+	require.Contains(t, dn, "cn=", "expected a CN-based DN")
+
+	pages := []string{
+		"/graph?entity=" + url.QueryEscape(dn) + "&depth=2",
+		"/users?view=graph",
+		"/groups?view=graph",
+		"/computers?view=graph",
+	}
+
+	axePath, err := filepath.Abs("internal/e2e/testdata/axe.min.js")
+	require.NoError(t, err, "resolve axe path")
+	axeSrc, err := os.ReadFile(axePath)
+	require.NoError(t, err, "read axe.min.js")
+
+	for _, target := range pages {
+		t.Run(target, func(t *testing.T) {
+			tp.Navigate(target)
+			// Wait for the graph canvas to appear so axe sees the
+			// fully-rendered page (v2-graph.js mutates DOM on load).
+			require.NoError(t, page.Locator("svg#graph-canvas").WaitFor())
+
+			_, err := page.Evaluate(string(axeSrc))
+			require.NoError(t, err, "inject axe")
+
+			result, err := page.Evaluate(`
+				() => axe.run(document, {
+					runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'] },
+					resultTypes: ['violations'],
+				})
+			`)
+			require.NoError(t, err, "axe.run")
+
+			raw, err := json.Marshal(result)
+			require.NoError(t, err, "marshal axe result")
+
+			var ar axeResult
+			require.NoError(t, json.Unmarshal(raw, &ar), "unmarshal axe result")
+
+			if len(ar.Violations) > 0 {
+				for _, v := range ar.Violations {
+					t.Errorf("axe violation [%s] on %s: %s — %d node(s). help: %s",
+						v.ID, target, v.Description, len(v.Nodes), v.HelpURL)
+					for i, n := range v.Nodes {
+						if i >= 3 {
+							t.Logf("  (and %d more node(s) truncated)", len(v.Nodes)-i)
+
+							break
+						}
+						t.Logf("  %s", n.Target)
+					}
+				}
+				t.Fatalf("%d axe violation(s) on %s", len(ar.Violations), target)
+			}
+
+			fmt.Fprintf(os.Stderr, "axe AA pass on %s: 0 violations\n", target)
+		})
+	}
+}

--- a/internal/e2e/axe_graph_test.go
+++ b/internal/e2e/axe_graph_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAxeAAA_GraphPages asserts the Phase 3 graph view pages have zero
-// WCAG violations under the same axe-core ruleset used by the login
-// page test. Covers:
+// TestAxeAA_GraphPages asserts the Phase 3 graph view pages have zero
+// WCAG 2.2 Level AA violations under axe-core. The graph view's stated
+// conformance level is AA (not AAA — the dynamic SVG/JS interactions
+// don't clear the AAA bar; the AAA-equivalent flat edge table below
+// the canvas provides the text alternative). The login page has a
+// separate AAA ratchet in TestAxeAAA_LoginPage. Covers:
 //   - /graph?entity=<seeded-DN>&depth=2 (entity-focused mode)
 //   - /users?view=graph                 (list-page Graph mode)
 //   - /groups?view=graph
@@ -25,7 +28,7 @@ import (
 // Authenticated as the test user; uses the first user from /users to
 // pick a real DN for the entity-focused page (matches the existing
 // graph_test.go pattern).
-func TestAxeAAA_GraphPages(t *testing.T) {
+func TestAxeAA_GraphPages(t *testing.T) {
 	config := DefaultTestConfig()
 	browser := NewTestBrowser(t, config)
 	defer browser.Close()

--- a/internal/web/templates/computers_v2.templ
+++ b/internal/web/templates/computers_v2.templ
@@ -359,6 +359,14 @@ templ computerDrawerContentsCtx(vm ComputerDrawerVM, inDrawer bool) {
 					</a>
 				</li>
 			}
+			<li>
+				<a class="drawer__pivot" href={ templ.URL("/graph?entity=" + url.QueryEscape(vm.Computer.DN())) }
+					aria-label="View relationship graph"
+					title="View relationship graph">
+					<span class="drawer__pivot-icon" aria-hidden="true">@iconGraph()</span>
+					<span class="drawer__pivot-text">View relationships</span>
+				</a>
+			</li>
 			if vm.OUPivotHref != "" {
 				<li>
 					<a class="drawer__pivot" href={ templ.URL(vm.OUPivotHref) } aria-label={ "Other computers in " + ouChipLabel(vm.OUName) } title={ "Other computers in " + vm.OUName }>

--- a/internal/web/templates/computers_v2.templ
+++ b/internal/web/templates/computers_v2.templ
@@ -361,8 +361,7 @@ templ computerDrawerContentsCtx(vm ComputerDrawerVM, inDrawer bool) {
 			}
 			<li>
 				<a class="drawer__pivot" href={ templ.URL("/graph?entity=" + url.QueryEscape(vm.Computer.DN())) }
-					aria-label="View relationship graph"
-					title="View relationship graph">
+					title="View relationships">
 					<span class="drawer__pivot-icon" aria-hidden="true">@iconGraph()</span>
 					<span class="drawer__pivot-text">View relationships</span>
 				</a>

--- a/internal/web/templates/graph_v2.templ
+++ b/internal/web/templates/graph_v2.templ
@@ -110,10 +110,8 @@ templ graphSVG(data *ldap_cache.GraphData, focusLabel string) {
 		id="graph-canvas"
 		class="graph-canvas"
 		viewBox="-500 -500 1000 1000"
-		role="img"
 		aria-labelledby="graph-canvas-title"
 		aria-describedby="graph-canvas-desc"
-		tabindex="-1"
 		focusable="false"
 	>
 		<title id="graph-canvas-title">{ "Relationship graph for " + focusLabel }</title>

--- a/internal/web/templates/graph_v2.templ
+++ b/internal/web/templates/graph_v2.templ
@@ -113,6 +113,8 @@ templ graphSVG(data *ldap_cache.GraphData, focusLabel string) {
 		role="img"
 		aria-labelledby="graph-canvas-title"
 		aria-describedby="graph-canvas-desc"
+		tabindex="-1"
+		focusable="false"
 	>
 		<title id="graph-canvas-title">{ "Relationship graph for " + focusLabel }</title>
 		<desc id="graph-canvas-desc">

--- a/internal/web/templates/graph_v2.templ
+++ b/internal/web/templates/graph_v2.templ
@@ -99,6 +99,12 @@ templ graphDepthSlider(current int, focusDN string) {
 // graphSVG renders the concentric SVG canvas. Nodes are positioned by
 // (Ring, Angle) from the cache builder; the viewBox is centred at the
 // origin so ring 0 sits in the middle.
+//
+// The <svg> itself is NOT focusable (no tabindex). Slice 4's
+// activateNodes() makes each .graph-node focusable instead, so axe's
+// nested-interactive rule (interactive parent + interactive child)
+// stays clean. Arrow-key pan still works because keydown bubbles from
+// the focused node up to the SVG-level listener in v2-graph.js.
 templ graphSVG(data *ldap_cache.GraphData, focusLabel string) {
 	<svg
 		id="graph-canvas"
@@ -107,7 +113,6 @@ templ graphSVG(data *ldap_cache.GraphData, focusLabel string) {
 		role="img"
 		aria-labelledby="graph-canvas-title"
 		aria-describedby="graph-canvas-desc"
-		tabindex="0"
 	>
 		<title id="graph-canvas-title">{ "Relationship graph for " + focusLabel }</title>
 		<desc id="graph-canvas-desc">

--- a/internal/web/templates/groups_v2.templ
+++ b/internal/web/templates/groups_v2.templ
@@ -369,6 +369,14 @@ templ groupDrawerContentsCtx(vm GroupDrawerVM, inDrawer bool) {
 					</a>
 				</li>
 			}
+			<li>
+				<a class="drawer__pivot" href={ templ.URL("/graph?entity=" + url.QueryEscape(asLdapGroup(vm.Group).DN())) }
+					aria-label="View relationship graph"
+					title="View relationship graph">
+					<span class="drawer__pivot-icon" aria-hidden="true">@iconGraph()</span>
+					<span class="drawer__pivot-text">View relationships</span>
+				</a>
+			</li>
 			if vm.OUPivotHref != "" {
 				<li>
 					<a class="drawer__pivot" href={ templ.URL(vm.OUPivotHref) } aria-label={ "Other groups in " + ouChipLabel(vm.OUName) } title={ "Other groups in " + vm.OUName }>

--- a/internal/web/templates/groups_v2.templ
+++ b/internal/web/templates/groups_v2.templ
@@ -371,8 +371,7 @@ templ groupDrawerContentsCtx(vm GroupDrawerVM, inDrawer bool) {
 			}
 			<li>
 				<a class="drawer__pivot" href={ templ.URL("/graph?entity=" + url.QueryEscape(asLdapGroup(vm.Group).DN())) }
-					aria-label="View relationship graph"
-					title="View relationship graph">
+					title="View relationships">
 					<span class="drawer__pivot-icon" aria-hidden="true">@iconGraph()</span>
 					<span class="drawer__pivot-text">View relationships</span>
 				</a>

--- a/internal/web/templates/icons.templ
+++ b/internal/web/templates/icons.templ
@@ -200,6 +200,21 @@ templ iconOSApple() {
 	</svg>
 }
 
+// iconGraph — four nodes connected as a square. Semantic for the
+// relationship-graph view introduced in Phase 3.
+templ iconGraph() {
+	<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+		<circle cx="6" cy="6" r="2.5"></circle>
+		<circle cx="18" cy="6" r="2.5"></circle>
+		<circle cx="6" cy="18" r="2.5"></circle>
+		<circle cx="18" cy="18" r="2.5"></circle>
+		<line x1="8.5" y1="6" x2="15.5" y2="6"></line>
+		<line x1="6" y1="8.5" x2="6" y2="15.5"></line>
+		<line x1="18" y1="8.5" x2="18" y2="15.5"></line>
+		<line x1="8.5" y1="18" x2="15.5" y2="18"></line>
+	</svg>
+}
+
 // iconForEntity dispatches to the appropriate glyph for a UI "type"
 // string: "user", "group", or "computer". Unknown values fall back to a
 // neutral dot so callers never crash on a typo.

--- a/internal/web/templates/icons.templ
+++ b/internal/web/templates/icons.templ
@@ -201,17 +201,18 @@ templ iconOSApple() {
 }
 
 // iconGraph — four nodes connected as a square. Semantic for the
-// relationship-graph view introduced in Phase 3.
+// relationship-graph view introduced in Phase 3. Matches the project
+// icon spec: 16-viewBox, 1.5 stroke, currentColor.
 templ iconGraph() {
-	<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-		<circle cx="6" cy="6" r="2.5"></circle>
-		<circle cx="18" cy="6" r="2.5"></circle>
-		<circle cx="6" cy="18" r="2.5"></circle>
-		<circle cx="18" cy="18" r="2.5"></circle>
-		<line x1="8.5" y1="6" x2="15.5" y2="6"></line>
-		<line x1="6" y1="8.5" x2="6" y2="15.5"></line>
-		<line x1="18" y1="8.5" x2="18" y2="15.5"></line>
-		<line x1="8.5" y1="18" x2="15.5" y2="18"></line>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+		<circle cx="4" cy="4" r="1.5"></circle>
+		<circle cx="12" cy="4" r="1.5"></circle>
+		<circle cx="4" cy="12" r="1.5"></circle>
+		<circle cx="12" cy="12" r="1.5"></circle>
+		<line x1="5.5" y1="4" x2="10.5" y2="4"></line>
+		<line x1="4" y1="5.5" x2="4" y2="10.5"></line>
+		<line x1="12" y1="5.5" x2="12" y2="10.5"></line>
+		<line x1="5.5" y1="12" x2="10.5" y2="12"></line>
 	</svg>
 }
 

--- a/internal/web/templates/users_v2.templ
+++ b/internal/web/templates/users_v2.templ
@@ -459,9 +459,8 @@ templ userDrawerContentsCtx(vm UserDrawerVM, inDrawer bool) {
 				</li>
 			}
 			<li>
-				<a class="drawer__pivot" href={ templ.URL("/graph?entity=" + url.QueryEscape(vm.User.User.DN())) }
-					aria-label="View relationship graph"
-					title="View relationship graph">
+				<a class="drawer__pivot" href={ templ.URL("/graph?entity=" + url.QueryEscape(vm.User.DN())) }
+					title="View relationships">
 					<span class="drawer__pivot-icon" aria-hidden="true">@iconGraph()</span>
 					<span class="drawer__pivot-text">View relationships</span>
 				</a>

--- a/internal/web/templates/users_v2.templ
+++ b/internal/web/templates/users_v2.templ
@@ -458,6 +458,14 @@ templ userDrawerContentsCtx(vm UserDrawerVM, inDrawer bool) {
 					</a>
 				</li>
 			}
+			<li>
+				<a class="drawer__pivot" href={ templ.URL("/graph?entity=" + url.QueryEscape(vm.User.User.DN())) }
+					aria-label="View relationship graph"
+					title="View relationship graph">
+					<span class="drawer__pivot-icon" aria-hidden="true">@iconGraph()</span>
+					<span class="drawer__pivot-text">View relationships</span>
+				</a>
+			</li>
 			if vm.OUPivotHref != "" {
 				<li>
 					<a class="drawer__pivot" href={ templ.URL(vm.OUPivotHref) } aria-label={ "Other users in " + ouChipLabel(vm.OUName) } title={ "Other users in " + vm.OUName }>


### PR DESCRIPTION
## Summary

Final slice of the Phase 3 relationship graph view. Adds the drawer entry point, the axe-core a11y ratchet, and the README conformance statement.

Plan: `docs/superpowers/plans/2026-04-24-phase-3-graph-view.md` Tasks 35-40. Slices 1-5 already on main (#581 / #582 / #584 / #585 / #586).

## What ships

- **"View relationships" drawer pivot** on user, group, and computer drawers (Tasks 35-36). Inserted as the second pivot after "Open full page", with a new `iconGraph` SVG (4 nodes connected as a square). Links to `/graph?entity=<DN>`.
- **`internal/e2e/axe_graph_test.go`** (Task 37) — runs axe-core against `/graph?entity=<seeded-DN>&depth=2`, `/users?view=graph`, `/groups?view=graph`, `/computers?view=graph`. Uses the WCAG 2.2 AA ruleset (graph view's stated conformance level — the AAA login ratchet stays in place separately). Each subtest waits for `svg#graph-canvas` so axe sees the JS-mutated DOM.
- **README accessibility section updated** (Task 39) — adds a sentence about the graph view's WCAG 2.2 AA conformance and the AAA-equivalent flat edge table fallback.

## Deferred

- **Task 38 (tab-order snapshot):** plan called for adding graph pages to a "tab-order snapshot suite" — but no such suite exists in the codebase. Building one from scratch for just three pages is a separate a11y-tooling effort. Deferred — file as a future enhancement.

## Tests

- All Slice 1-5 tests still pass.
- New axe-core ratchet runs in CI under the `e2e` build tag.

## Test plan

- [x] `go build ./...` — clean
- [x] `go build -tags e2e ./internal/e2e/...` — clean
- [x] `go test ./... -count=1` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI verification on push (unit + integration + e2e)
- [ ] Manual smoke (after merge): open a user drawer → click "View relationships" → confirm graph renders → use the `List | Graph` toggle to switch back

## Phase 3 complete

This PR closes out the Phase 3 relationship graph view per spec `docs/superpowers/specs/2026-04-24-phase-3-graph-view-design.md`. With this merged:

- `BuildGraph(focusDN, depth)` + `BuildListGraph(users, computers)` in-memory builders (Slice 1, Slice 5)
- `/api/graph.json?entity=…&depth=…` JSON endpoint with ETag/304/RFC 7232 (Slice 2)
- `/graph` HTML page with SSR SVG + edge table (Slice 3)
- `v2-graph.js` interactive client: pan/zoom, keyboard nav, click-to-pivot, click-to-expand, depth slider auto-submit, ARIA live announce (Slice 4)
- `?view=graph` list-page mode for users/groups/computers with `List | Graph` segmented toggle (Slice 5)
- "View relationships" drawer pivot + axe-core ratchet + README conformance (this PR)