### PR TITLE
feat/fix(graph): post-Phase-3 polish — Table view, persistent selection, weighting, dark-mode + bug fixes

### DIFF
--- a/internal/ldap_cache/graph.go
+++ b/internal/ldap_cache/graph.go
@@ -46,6 +46,7 @@ type Node struct {
 	Label       string   `json:"label"`
 	Ring        int      `json:"ring"`
 	Angle       float64  `json:"angle"`
+	Degree      int      `json:"degree"`                // edges incident to this node within the rendered set
 	Enabled     *bool    `json:"enabled,omitempty"`     // user / computer only
 	MemberCount *int     `json:"memberCount,omitempty"` // group only
 	Expandable  bool     `json:"expandable"`
@@ -107,18 +108,21 @@ func (m *Manager) BuildGraph(focusDN string, depth int) (*GraphData, error) {
 	// Resolve focus type.
 	if u, ok := m.Users.FindByDN(focusDN); ok {
 		data := m.buildGraphFromUser(*u, depth)
+		assignDegrees(data)
 		assignConcentric(data)
 
 		return data, nil
 	}
 	if g, ok := m.Groups.FindByDN(focusDN); ok {
 		data := m.buildGraphFromGroup(*g, depth)
+		assignDegrees(data)
 		assignConcentric(data)
 
 		return data, nil
 	}
 	if c, ok := m.Computers.FindByDN(focusDN); ok {
 		data := m.buildGraphFromComputer(*c, depth)
+		assignDegrees(data)
 		assignConcentric(data)
 
 		return data, nil
@@ -128,6 +132,7 @@ func (m *Manager) BuildGraph(focusDN string, depth int) (*GraphData, error) {
 		len(parsed.RDNs) > 0 &&
 		strings.EqualFold(parsed.RDNs[0].Attributes[0].Type, "ou") {
 		data := m.buildGraphFromOU(focusDN, depth)
+		assignDegrees(data)
 		assignConcentric(data)
 
 		return data, nil
@@ -163,6 +168,7 @@ func (m *Manager) BuildListGraph(filtered []ldap.User, filteredComputers []ldap.
 	}
 
 	applyCaps(data)
+	assignDegrees(data)
 	assignConcentric(data)
 
 	return data
@@ -295,9 +301,36 @@ func (m *Manager) buildGraphFromOU(dn string, depth int) *GraphData {
 	return data
 }
 
-// assignConcentric writes (ring, angle) onto each Node. Ring is already
-// set by the builder; this function picks angles. Nodes in the same ring
-// are sorted by (Type, Label, DN) for determinism, then evenly spaced.
+// assignDegrees counts edges incident to each node (within the
+// rendered set) and writes the count to Node.Degree. Used by the
+// client-side renderer to scale disc radius proportionally — high-
+// degree nodes (e.g. groups with many members) read as visually
+// "weightier" than leaves.
+func assignDegrees(d *GraphData) {
+	deg := make(map[string]int, len(d.Nodes))
+	for _, e := range d.Edges {
+		deg[e.Source]++
+		deg[e.Target]++
+	}
+
+	for i := range d.Nodes {
+		d.Nodes[i].Degree = deg[d.Nodes[i].DN]
+	}
+}
+
+// assignConcentric writes (ring, angle) onto each Node.
+//
+// Ring 0 sits at the origin (single focal node). Ring 1 is sorted by
+// (Type, Label, DN) since every node connects to ring 0 and there is
+// no parent structure to anchor against.
+//
+// Rings 2+ use parent-anchored placement: each node's "parent" is the
+// ring-(N-1) node it shares an edge with. Children of the same parent
+// occupy a contiguous arc whose centre matches the parent's angle and
+// whose width is proportional to the parent's child count. Result:
+// the layout reads as spokes radiating outward, so visually-clustered
+// nodes really do share a connection — answering the "the graph feels
+// random" complaint without needing animation.
 func assignConcentric(d *GraphData) {
 	buckets := map[int][]*Node{}
 	for i := range d.Nodes {
@@ -305,29 +338,142 @@ func assignConcentric(d *GraphData) {
 		buckets[n.Ring] = append(buckets[n.Ring], n)
 	}
 
-	for ring, nodes := range buckets {
-		if ring == 0 {
-			for _, n := range nodes {
-				n.Angle = 0
+	// Ring 0: focus.
+	for _, n := range buckets[0] {
+		n.Angle = 0
+	}
+
+	// Ring 1: alphabetical, evenly spaced.
+	if r1 := buckets[1]; len(r1) > 0 {
+		sort.Slice(r1, func(i, j int) bool {
+			if r1[i].Type != r1[j].Type {
+				return r1[i].Type < r1[j].Type
+			}
+			if r1[i].Label != r1[j].Label {
+				return r1[i].Label < r1[j].Label
 			}
 
+			return r1[i].DN < r1[j].DN
+		})
+
+		for i, n := range r1 {
+			n.Angle = float64(i) * 2 * math.Pi / float64(len(r1))
+		}
+	}
+
+	// Build a DN → ring lookup so the parent search can stop at
+	// the correct ring without rescanning the full node slice.
+	ringOf := make(map[string]int, len(d.Nodes))
+	for _, n := range d.Nodes {
+		ringOf[n.DN] = n.Ring
+	}
+
+	for ring := 2; ring <= 3; ring++ {
+		nodes := buckets[ring]
+		if len(nodes) == 0 {
 			continue
 		}
 
-		sort.Slice(nodes, func(i, j int) bool {
-			if nodes[i].Type != nodes[j].Type {
-				return nodes[i].Type < nodes[j].Type
-			}
-			if nodes[i].Label != nodes[j].Label {
-				return nodes[i].Label < nodes[j].Label
+		assignParentAnchoredAngles(d, nodes, ring, ringOf)
+	}
+}
+
+// assignParentAnchoredAngles places each ring-N node near the angle of
+// its ring-(N-1) parent. Children of the same parent share an arc; the
+// arc's width scales with the child count so a parent with many
+// children doesn't crowd a parent with few.
+func assignParentAnchoredAngles(d *GraphData, nodes []*Node, ring int, ringOf map[string]int) {
+	// Group ring-N nodes by parent DN. A node may have multiple parents
+	// (e.g. a user that's a member of two visible groups); pick the
+	// parent with the smallest DN for stability across renders.
+	type child struct {
+		node     *Node
+		parentDN string
+	}
+
+	children := make([]child, 0, len(nodes))
+
+	for _, n := range nodes {
+		var bestParent string
+
+		for _, e := range d.Edges {
+			var candidate string
+
+			switch {
+			case e.Source == n.DN && ringOf[e.Target] == ring-1:
+				candidate = e.Target
+			case e.Target == n.DN && ringOf[e.Source] == ring-1:
+				candidate = e.Source
 			}
 
-			return nodes[i].DN < nodes[j].DN
+			if candidate != "" && (bestParent == "" || candidate < bestParent) {
+				bestParent = candidate
+			}
+		}
+
+		children = append(children, child{node: n, parentDN: bestParent})
+	}
+
+	// Group by parent, preserving deterministic order. Orphaned nodes
+	// (no parent in the previous ring — shouldn't happen but defensive)
+	// land in a single residual bucket placed at angle 0.
+	groups := map[string][]*Node{}
+	parentOrder := []string{}
+
+	for _, c := range children {
+		if _, ok := groups[c.parentDN]; !ok {
+			parentOrder = append(parentOrder, c.parentDN)
+		}
+
+		groups[c.parentDN] = append(groups[c.parentDN], c.node)
+	}
+
+	// Sort parents by their own angle so children inherit the same
+	// circular order. Orphans (parentDN=="") sort last.
+	parentAngle := map[string]float64{}
+
+	for _, n := range d.Nodes {
+		parentAngle[n.DN] = n.Angle
+	}
+
+	sort.SliceStable(parentOrder, func(i, j int) bool {
+		ai, oi := parentAngle[parentOrder[i]], parentOrder[i] == ""
+		aj, oj := parentAngle[parentOrder[j]], parentOrder[j] == ""
+
+		if oi != oj {
+			return !oi
+		}
+
+		return ai < aj
+	})
+
+	// Allocate each parent an arc proportional to its child count, then
+	// distribute children evenly inside that arc, centred on the
+	// parent's angle.
+	totalChildren := len(nodes)
+	arcPerChild := 2 * math.Pi / float64(totalChildren)
+
+	for _, parent := range parentOrder {
+		group := groups[parent]
+		// Sort within group for stability.
+		sort.Slice(group, func(i, j int) bool {
+			if group[i].Type != group[j].Type {
+				return group[i].Type < group[j].Type
+			}
+			if group[i].Label != group[j].Label {
+				return group[i].Label < group[j].Label
+			}
+
+			return group[i].DN < group[j].DN
 		})
 
-		count := len(nodes)
-		for i, n := range nodes {
-			n.Angle = float64(i) * 2 * math.Pi / float64(count)
+		arcWidth := arcPerChild * float64(len(group))
+		centre := parentAngle[parent]
+
+		// Spread children symmetrically around the parent angle.
+		for i, n := range group {
+			offset := (float64(i) + 0.5) * arcPerChild
+			n.Angle = centre - arcWidth/2 + offset
 		}
 	}
 }

--- a/internal/ldap_cache/manager.go
+++ b/internal/ldap_cache/manager.go
@@ -316,14 +316,20 @@ func (m *Manager) Refresh() {
 // FindUsers returns all cached users, optionally filtering out disabled users.
 // When showDisabled is true, returns all users including disabled ones.
 // When false, returns only enabled users. Uses efficient filtering on cached data.
+//
+// Also excludes any DN present in the Computers cache. Active Directory's
+// `objectClass=user` filter matches computer accounts too (computers inherit
+// from user in the AD schema), and simple-ldap-go's FindUsers uses that
+// broad filter. Without this exclusion the /users list shows machine
+// accounts alongside real users on AD-backed deployments.
 func (m *Manager) FindUsers(showDisabled bool) []ldap.User {
-	if !showDisabled {
-		return m.Users.Filter(func(u ldap.User) bool {
-			return u.Enabled
-		})
-	}
+	return m.Users.Filter(func(u ldap.User) bool {
+		if _, isComputer := m.Computers.FindByDN(u.DN()); isComputer {
+			return false
+		}
 
-	return m.Users.Get()
+		return showDisabled || u.Enabled
+	})
 }
 
 // FindUserByDN finds a user by their Distinguished Name (DN) in the cache.

--- a/internal/web/computers_v2_handler.go
+++ b/internal/web/computers_v2_handler.go
@@ -90,9 +90,11 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 		currentView = "list"
 	}
 
+	filterQS := templates.ComputersFilterQS(ouFilter)
+
 	if currentView == "graph" {
 		data := a.ldapCache.BuildListGraph(nil, computers)
-		vm := templates.GraphPageVM{Data: data, BackHref: "/computers", FocusLabel: "Computers"}
+		vm := templates.GraphPageVM{Data: data, BackHref: "/computers", FocusLabel: "Computers", FilterQS: filterQS}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
 	}
@@ -100,7 +102,7 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 	if currentView == "table" {
 		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-		return templates.ComputersListTableV2(computers, currentView, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+		return templates.ComputersListTableV2(computers, currentView, filterQS, a.takeFlash(c), a.paletteContextFor(viewerDN)).
 			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 

--- a/internal/web/computers_v2_handler.go
+++ b/internal/web/computers_v2_handler.go
@@ -85,16 +85,23 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 
 	sortComputersByCN(computers)
 
-	currentView := c.Query("view")
+	currentView := pickView(c)
 	if a.ldapCache == nil {
-		currentView = ""
+		currentView = "list"
 	}
 
-	if currentView == "graph" && a.ldapCache != nil {
+	if currentView == "graph" {
 		data := a.ldapCache.BuildListGraph(nil, computers)
 		vm := templates.GraphPageVM{Data: data, BackHref: "/computers", FocusLabel: "Computers"}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
+	}
+
+	if currentView == "table" {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
+
+		return templates.ComputersListTableV2(computers, currentView, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 
 	ous := distinctImmediateOUsFromComputers(all)

--- a/internal/web/graph_v2_handler_test.go
+++ b/internal/web/graph_v2_handler_test.go
@@ -313,3 +313,129 @@ func TestHandleComputersV2_GraphMode(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleUsersV2_TableMode covers the new ?view=table branch — the
+// full-width Table view with no filter rail or detail drawer.
+func TestHandleUsersV2_TableMode(t *testing.T) {
+	app, store := setupFullTestApp(t)
+	cachetest.Seed(app.ldapCache,
+		[]ldap.User{
+			cachetest.NewUserWithDN(bobDN, "bob", "bob", true, nil),
+		},
+		nil,
+		nil,
+	)
+
+	cookies := createAuthSession(t, app, store)
+	req := httptest.NewRequest("GET", "/users?view=table", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, resp.Header.Get("Content-Type"), "text/html",
+		"table render must declare HTML content-type — earlier omission caused browsers to display raw HTML")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	html := string(body)
+
+	for _, marker := range []string{
+		`class="list-table"`,
+		`<th scope="col">CN</th>`,
+		"bob",
+		`graph-segmented`,
+	} {
+		require.Contains(t, html, marker, "missing table-view marker %q", marker)
+	}
+}
+
+// TestHandleGroupsV2_TableMode mirrors TestHandleUsersV2_TableMode.
+func TestHandleGroupsV2_TableMode(t *testing.T) {
+	app, store := setupFullTestApp(t)
+	const engineersDN = "cn=engineers,ou=Groups,dc=test,dc=local"
+	cachetest.Seed(app.ldapCache, nil,
+		[]ldap.Group{
+			cachetest.NewGroupWithDN(engineersDN, "engineers", []string{bobDN}),
+		},
+		nil,
+	)
+
+	cookies := createAuthSession(t, app, store)
+	req := httptest.NewRequest("GET", "/groups?view=table", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `class="list-table"`)
+	require.Contains(t, string(body), "engineers")
+}
+
+// TestHandleComputersV2_TableMode mirrors the user/group versions.
+func TestHandleComputersV2_TableMode(t *testing.T) {
+	app, store := setupFullTestApp(t)
+	const ws01DN = "cn=ws01,ou=Computers,dc=test,dc=local"
+	cachetest.Seed(app.ldapCache, nil, nil, []ldap.Computer{
+		cachetest.NewComputerWithDN(ws01DN, "ws01", "ws01$", true, nil),
+	})
+
+	cookies := createAuthSession(t, app, store)
+	req := httptest.NewRequest("GET", "/computers?view=table", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `class="list-table"`)
+	require.Contains(t, string(body), "ws01")
+}
+
+// TestHandleUsersV2_PersistentViewViaCookie covers the cookie path:
+// when no ?view= is in the URL, pickView falls back to the graph-view
+// cookie. Earlier the template-cache key didn't include the cookie, so
+// the first cached response stuck regardless of preference.
+func TestHandleUsersV2_PersistentViewViaCookie(t *testing.T) {
+	app, store := setupFullTestApp(t)
+	cachetest.Seed(app.ldapCache,
+		[]ldap.User{
+			cachetest.NewUserWithDN(bobDN, "bob", "bob", true, nil),
+		},
+		nil, nil,
+	)
+
+	cookies := createAuthSession(t, app, store)
+	req := httptest.NewRequest("GET", "/users", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	req.AddCookie(&http.Cookie{Name: "graph-view", Value: "table"})
+
+	resp, err := app.fiber.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `class="list-table"`,
+		"cookie should resolve to table view when no ?view= is set")
+}

--- a/internal/web/graph_view.go
+++ b/internal/web/graph_view.go
@@ -1,0 +1,61 @@
+// internal/web/graph_view.go — list-page view-mode helpers.
+package web
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+// graphViewCookie is the cookie name used to remember the user's
+// preferred list-page view mode. Reads / writes go through pickView so
+// the storage detail stays local to this file.
+const graphViewCookie = "graph-view"
+
+// pickView resolves the effective list-page view mode for the current
+// request and persists explicit choices to a cookie so the preference
+// follows the user across /users, /groups, and /computers.
+//
+// Resolution order:
+//  1. ?view=… query parameter (explicit choice — set the cookie).
+//  2. graph-view cookie (sticky preference from a previous request).
+//  3. "list" (default).
+//
+// Unknown values normalise to "list" so a typo'd URL doesn't render
+// nothing.
+func pickView(c *fiber.Ctx) string {
+	if raw := c.Query("view"); raw != "" {
+		v := normaliseView(raw)
+		setViewCookie(c, v)
+
+		return v
+	}
+
+	return normaliseView(c.Cookies(graphViewCookie))
+}
+
+// normaliseView clamps an unknown view string to the safe default. Any
+// new view modes need to be added here AND to the segmented toggle in
+// internal/web/templates/graph_toggle.templ.
+func normaliseView(s string) string {
+	switch s {
+	case "list", "table", "graph":
+		return s
+	default:
+		return "list"
+	}
+}
+
+// setViewCookie writes the user's explicit choice so future requests
+// without ?view= still resolve to the same mode. SameSite=Strict
+// matches the rest of the session security profile; HTTPOnly keeps the
+// preference out of JS reach (the segmented toggle reads `currentView`
+// from the rendered template, not from the cookie).
+func setViewCookie(c *fiber.Ctx, v string) {
+	c.Cookie(&fiber.Cookie{
+		Name:     graphViewCookie,
+		Value:    v,
+		Path:     "/",
+		MaxAge:   30 * 24 * 3600, // 30 days
+		HTTPOnly: true,
+		SameSite: "Strict",
+	})
+}

--- a/internal/web/graph_view.go
+++ b/internal/web/graph_view.go
@@ -45,16 +45,19 @@ func normaliseView(s string) string {
 }
 
 // setViewCookie writes the user's explicit choice so future requests
-// without ?view= still resolve to the same mode. SameSite=Strict
-// matches the rest of the session security profile; HTTPOnly keeps the
-// preference out of JS reach (the segmented toggle reads `currentView`
-// from the rendered template, not from the cookie).
+// without ?view= still resolve to the same mode. SameSite=Strict +
+// HTTPOnly match the rest of the session security profile. Secure is
+// derived from the request's own protocol so HTTPS deployments get the
+// flag without needing to plumb opts.CookieSecure through to here, and
+// HTTP-only dev deployments don't break by trying to set a Secure
+// cookie that the browser would refuse.
 func setViewCookie(c *fiber.Ctx, v string) {
 	c.Cookie(&fiber.Cookie{
 		Name:     graphViewCookie,
 		Value:    v,
 		Path:     "/",
 		MaxAge:   30 * 24 * 3600, // 30 days
+		Secure:   c.Protocol() == "https",
 		HTTPOnly: true,
 		SameSite: "Strict",
 	})

--- a/internal/web/groups_v2_handler.go
+++ b/internal/web/groups_v2_handler.go
@@ -296,12 +296,12 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 	groups = filterGroupsByMember(groups, memberDN)
 	sortGroupsByCN(groups)
 
-	currentView := c.Query("view")
+	currentView := pickView(c)
 	if a.ldapCache == nil {
-		currentView = ""
+		currentView = "list"
 	}
 
-	if currentView == "graph" && a.ldapCache != nil {
+	if currentView == "graph" {
 		members := make([]ldap.User, 0)
 		computers := make([]ldap.Computer, 0)
 		seenMember := make(map[string]struct{})
@@ -322,6 +322,13 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 		vm := templates.GraphPageVM{Data: data, BackHref: "/groups", FocusLabel: "Groups"}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
+	}
+
+	if currentView == "table" {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
+
+		return templates.GroupsListTableV2(groups, currentView, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 
 	memberCN := lookupUserCN(memberDN, a.ldapCache)

--- a/internal/web/groups_v2_handler.go
+++ b/internal/web/groups_v2_handler.go
@@ -301,6 +301,8 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 		currentView = "list"
 	}
 
+	filterQS := templates.GroupsFilterQS(ouFilter, memberDN)
+
 	if currentView == "graph" {
 		members := make([]ldap.User, 0)
 		computers := make([]ldap.Computer, 0)
@@ -319,7 +321,7 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 			}
 		}
 		data := a.ldapCache.BuildListGraph(members, computers)
-		vm := templates.GraphPageVM{Data: data, BackHref: "/groups", FocusLabel: "Groups"}
+		vm := templates.GraphPageVM{Data: data, BackHref: "/groups", FocusLabel: "Groups", FilterQS: filterQS}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
 	}
@@ -327,7 +329,7 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 	if currentView == "table" {
 		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-		return templates.GroupsListTableV2(groups, currentView, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+		return templates.GroupsListTableV2(groups, currentView, filterQS, a.takeFlash(c), a.paletteContextFor(viewerDN)).
 			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 

--- a/internal/web/static/app.css
+++ b/internal/web/static/app.css
@@ -2664,10 +2664,13 @@ button.kv-edit__save {
   --graph-edge-focus: #0a0a0a;
   --graph-node-border: #525252;     /* AAA 7.8 on #fff */
   --graph-node-focus-ring: #0a0a0a;
-  --graph-node-bg-user: #fafafa;
+  /* Disc fills MUST contrast with --bg-subtle (the canvas background)
+     — earlier values matched the canvas exactly, leaving discs visible
+     only via their stroke. */
+  --graph-node-bg-user: #ffffff;
   --graph-node-bg-group: #e5e5e5;
   --graph-node-bg-computer: #d4d4d4;
-  --graph-node-bg-ou: #ffffff;
+  --graph-node-bg-ou: #f0f0f0;
 }
 
 :root[data-theme="dark"] {
@@ -2675,9 +2678,11 @@ button.kv-edit__save {
   --graph-edge-focus: #f5f5f5;
   --graph-node-border: #d4d4d4;
   --graph-node-focus-ring: #4ade80;
-  --graph-node-bg-user: #1a1a1a;
-  --graph-node-bg-group: #262626;
-  --graph-node-bg-computer: #333333;
+  /* Same logic as light theme — bumped one tone away from --bg-subtle
+     (#1a1a1a) so the disc body is visible, not just the border. */
+  --graph-node-bg-user: #2a2a2a;
+  --graph-node-bg-group: #383838;
+  --graph-node-bg-computer: #454545;
   --graph-node-bg-ou: #0d0d0d;
 }
 
@@ -2694,7 +2699,8 @@ button.kv-edit__save {
 .graph-canvas:focus-visible { outline: 2px solid var(--border-strong); outline-offset: 2px; }
 
 .graph-edge { stroke: var(--graph-edge); stroke-width: 1.5; fill: none; }
-.graph-edge:hover { stroke: var(--graph-edge-focus); stroke-width: 2; }
+.graph-edge:hover,
+.graph-edge--hover-related { stroke: var(--graph-edge-focus); stroke-width: 2; }
 
 .graph-node { cursor: pointer; }
 .graph-node__disc { fill: var(--graph-node-bg-user); stroke: var(--graph-node-border); stroke-width: 1.5; }

--- a/internal/web/static/app.css
+++ b/internal/web/static/app.css
@@ -968,8 +968,27 @@ a.home__quick-card:focus-visible .home__quick-card-arrow {
 .list-page__head {
     display: flex;
     align-items: baseline;
-    gap: 0.75rem;
+    gap: 1rem;
     margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+}
+
+/* Title cluster (h1 + count) sits at the left; controls cluster
+   (filters/slider/segmented toggle) auto-margins to the right so the
+   toggle stays in a stable screen position across List/Table/Graph
+   views regardless of how many other controls a view has. */
+.list-page__head-titles {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+}
+
+.list-page__head-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-left: auto;
+    flex-wrap: wrap;
 }
 
 .list-page__title {
@@ -2686,14 +2705,25 @@ button.kv-edit__save {
   --graph-node-bg-ou: #0d0d0d;
 }
 
-.graph-page { padding: 1rem; display: flex; flex-direction: column; gap: 1.5rem; }
+/* Match .list-page width/centering so the List|Table|Graph headers align
+   identically across views (see header consistency feedback). */
+.graph-page { max-width: 72rem; width: 100%; margin: 1.5rem auto 0; padding: 0 1rem 1.5rem; display: flex; flex-direction: column; gap: 1.5rem; }
 .graph-page__head { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; }
 .graph-page__title { margin: 0; }
 .graph-page__overflow { color: var(--fg-muted); font-size: 0.9rem; }
+/* Explicit color on the visible "Relationships" section header so it
+   honours the theme — Pico's defaults for h2 may not pick up --fg in
+   the dark/console mode. */
+.graph-table-section h2 { color: var(--fg); }
 
-.graph-slider { display: inline-flex; gap: 0.5rem; align-items: center; }
+.graph-slider { display: inline-flex; gap: 0.5rem; align-items: center; color: var(--fg); }
 .graph-slider__label { font-weight: 600; }
 .graph-slider__value { font-variant-numeric: tabular-nums; min-width: 1.5em; text-align: center; }
+/* accent-color themes the native range track + thumb to match the
+   active --accent token (green in dark/console mode, near-black in
+   light). Without it the slider keeps the platform default which
+   reads as a bright-white control on a dark page. */
+.graph-slider input[type="range"] { accent-color: var(--accent); }
 
 .graph-canvas { width: 100%; height: min(70vh, 640px); background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 8px; }
 .graph-canvas:focus-visible { outline: 2px solid var(--border-strong); outline-offset: 2px; }
@@ -2707,14 +2737,16 @@ button.kv-edit__save {
 .graph-node--group .graph-node__disc { fill: var(--graph-node-bg-group); stroke-dasharray: 4 3; }
 .graph-node--computer .graph-node__disc { fill: var(--graph-node-bg-computer); }
 .graph-node--ou .graph-node__disc { fill: var(--graph-node-bg-ou); }
-.graph-node__label { fill: var(--fg); font-size: 12px; font-weight: 500; pointer-events: none; }
+/* font-family: inherit so the node label picks up the body's monospace
+   font in dark/console mode (see :root[data-theme="dark"] body rule). */
+.graph-node__label { fill: var(--fg); font-family: inherit; font-size: 12px; font-weight: 500; pointer-events: none; }
 .graph-node:focus-visible .graph-node__disc { outline: 2px solid var(--graph-node-focus-ring); outline-offset: 2px; }
 .graph-node__expand-badge-bg { fill: var(--accent); }
 .graph-node__expand-badge-mark { fill: var(--bg); font-size: 12px; font-weight: 700; }
 
-.graph-table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+.graph-table { width: 100%; border-collapse: collapse; font-family: inherit; font-size: 0.9rem; color: var(--fg); }
 .graph-table th, .graph-table td { text-align: left; padding: 0.4rem 0.8rem; border-bottom: 1px solid var(--border); }
-.graph-table th { background: var(--bg-subtle); text-transform: uppercase; font-size: 0.8rem; letter-spacing: 0.03em; }
+.graph-table th { background: var(--bg-subtle); color: var(--fg); text-transform: uppercase; font-size: 0.8rem; letter-spacing: 0.03em; }
 .graph-table tr:focus-within { outline: 2px solid var(--border-strong); outline-offset: -2px; }
 .graph-table__sort { color: var(--fg); text-decoration: none; }
 .graph-table__sort:hover { text-decoration: underline; }
@@ -2727,6 +2759,30 @@ button.kv-edit__save {
 .graph-segmented__option { padding: 0.4rem 1rem; color: var(--fg-muted); text-decoration: none; }
 .graph-segmented__option:first-child { border-top-left-radius: 999px; border-bottom-left-radius: 999px; }
 .graph-segmented__option:last-child { border-top-right-radius: 999px; border-bottom-right-radius: 999px; }
-.graph-segmented__option:hover { background: var(--bg-subtle); }
+/* Don't apply hover styling to the active option — its accent
+   background swaps to --bg-subtle (which equals --bg in dark mode and
+   reads as black-on-black). The active option stays solid through
+   hover instead. */
+.graph-segmented__option:hover:not(.graph-segmented__option--active) { background: var(--bg-subtle); }
 .graph-segmented__option--active { background: var(--accent); color: var(--bg); }
 .graph-segmented__option:focus-visible { outline: 2px solid var(--border-strong); outline-offset: 2px; }
+
+/* ============================================================
+   List → Table view (third segment of List | Table | Graph)
+   ============================================================ */
+
+/* Same max-width/centering as .list-page and .graph-page for consistent
+   subheader alignment across all three views. */
+.list-table-page { max-width: 72rem; width: 100%; margin: 1.5rem auto 0; padding: 0 1rem 1.5rem; display: flex; flex-direction: column; gap: 1rem; }
+.list-table-page__head { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; flex-wrap: wrap; }
+.list-table-page__title { margin: 0; }
+.list-table-page__count { color: var(--fg-muted); font-size: 0.9rem; }
+
+.list-table { width: 100%; border-collapse: collapse; font-family: inherit; font-size: 0.95rem; color: var(--fg); }
+.list-table th, .list-table td { text-align: left; padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--border); }
+.list-table th { background: var(--bg-subtle); color: var(--fg); text-transform: uppercase; font-size: 0.8rem; letter-spacing: 0.03em; font-weight: 600; }
+.list-table tbody tr:hover { background: var(--bg-subtle); }
+.list-table__link { color: var(--fg); text-decoration: none; font-weight: 500; }
+.list-table__link:hover { text-decoration: underline; }
+.list-table__num { font-variant-numeric: tabular-nums; text-align: right; }
+.list-table__dn { color: var(--fg-muted); font-family: var(--font-mono, monospace); font-size: 0.85rem; word-break: break-all; }

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -21,9 +21,6 @@
     var el = document.getElementById("graph-data");
     if (!el) return null;
     try {
-      // <template> content lives in a separate DocumentFragment.
-      // Slice 3 chose <template> over <script type="application/json">
-      // for CSP-safety under script-src 'self'.
       var text = el.content ? el.content.textContent : el.textContent;
       return JSON.parse(text);
     } catch (e) {
@@ -51,6 +48,17 @@
     return n.label;
   }
 
+  // labelHint composes the keyboard-affordance suffix for an aria-label.
+  // Mirrors the suffix logic in activateNodes + renderNode so all nodes
+  // carry consistent SR text. `expandable` is "true" for `+`, "expanded"
+  // for `-`, anything else for "no badge".
+  function labelHint(expandable) {
+    var hint = " Press Enter to open.";
+    if (expandable === "true") hint += " Press + to expand more relations.";
+    if (expandable === "expanded") hint += " Press - to collapse.";
+    return hint;
+  }
+
   // activateNodes makes each rendered .graph-node keyboard-focusable
   // and properly labelled now that the JS handlers exist. Slice 3
   // deliberately omitted these attributes from the SSR template.
@@ -60,16 +68,54 @@
       n.setAttribute("tabindex", "0");
       n.setAttribute("role", "button");
       var label = n.getAttribute("aria-label") || "";
-      if (label && label.indexOf("Press Enter to open.") === -1) {
-        label = label + " Press Enter to open.";
-      }
-      if (
-        n.getAttribute("data-expandable") === "true" &&
-        label.indexOf("Press + to expand") === -1
-      ) {
-        label = label + " Press + to expand more relations.";
-      }
+      // Strip any prior hint so re-activations don't pile suffixes.
+      var cut = label.indexOf(" Press Enter");
+      if (cut !== -1) label = label.substring(0, cut);
+      label += labelHint(n.getAttribute("data-expandable"));
       n.setAttribute("aria-label", label);
+    });
+  }
+
+  // wireHoverHighlight: hovering a node highlights its incident edges
+  // by toggling a .graph-edge--hover-related class on every edge whose
+  // data-source or data-target equals the node's DN.
+  function wireHoverHighlight(svg) {
+    function setHighlight(dn, on) {
+      if (!dn) return;
+      var sel =
+        '.graph-edge[data-source="' +
+        CSS.escape(dn) +
+        '"], .graph-edge[data-target="' +
+        CSS.escape(dn) +
+        '"]';
+      svg.querySelectorAll(sel).forEach(function (line) {
+        line.classList.toggle("graph-edge--hover-related", on);
+      });
+    }
+    svg.addEventListener("mouseover", function (e) {
+      var node = e.target.closest(".graph-node");
+      if (!node) return;
+      setHighlight(node.getAttribute("data-dn"), true);
+    });
+    svg.addEventListener("mouseout", function (e) {
+      var node = e.target.closest(".graph-node");
+      if (!node) return;
+      // mouseout fires when leaving inner SVG elements too; only un-set
+      // the highlight when the relatedTarget isn't still inside the same
+      // node group.
+      var to = e.relatedTarget;
+      if (to && node.contains(to)) return;
+      setHighlight(node.getAttribute("data-dn"), false);
+    });
+    svg.addEventListener("focusin", function (e) {
+      var node = e.target.closest(".graph-node");
+      if (!node) return;
+      setHighlight(node.getAttribute("data-dn"), true);
+    });
+    svg.addEventListener("focusout", function (e) {
+      var node = e.target.closest(".graph-node");
+      if (!node) return;
+      setHighlight(node.getAttribute("data-dn"), false);
     });
   }
 
@@ -84,8 +130,24 @@
     activateNodes(svg);
     wirePanZoom(svg, viewport);
     wireNodeClicks(svg, state);
+    wireHoverHighlight(svg);
     wireDepthSlider();
   });
+
+  // userSpacePoint converts a screen-coord MouseEvent into the SVG's
+  // own user-space coordinate system (the one the inner viewport <g>
+  // is positioned in). Without this, cursor-anchored zoom math would
+  // mix screen pixels with viewBox units and drift relative to the
+  // pointer.
+  function userSpacePoint(svg, e) {
+    var pt = svg.createSVGPoint();
+    pt.x = e.clientX;
+    pt.y = e.clientY;
+    var ctm = svg.getScreenCTM();
+    if (!ctm) return { x: 0, y: 0 };
+    var p = pt.matrixTransform(ctm.inverse());
+    return { x: p.x, y: p.y };
+  }
 
   function wirePanZoom(svg, viewport) {
     var tx = 0,
@@ -124,31 +186,31 @@
     });
 
     // Wheel zoom only when modifier key is held — without ctrl/meta the
-    // page scroll behaviour is preserved. Zoom around the cursor so the
-    // world-space point under the pointer stays put after the scale
-    // change (standard map/graph UX).
+    // page scroll behaviour is preserved. Anchor zoom around the
+    // pointer's USER-SPACE position so the world-point under the cursor
+    // stays put across the scale change. (Earlier versions mixed screen
+    // pixels with viewBox units and drifted noticeably.)
     svg.addEventListener(
       "wheel",
       function (e) {
         if (!(e.ctrlKey || e.metaKey)) return;
         e.preventDefault();
-        var rect = svg.getBoundingClientRect();
-        var cx = e.clientX - rect.left;
-        var cy = e.clientY - rect.top;
         var oldScale = scale;
         var delta = -e.deltaY * 0.001;
         scale = Math.min(3, Math.max(0.3, scale * (1 + delta)));
         if (oldScale !== scale) {
-          tx = cx - ((cx - tx) * scale) / oldScale;
-          ty = cy - ((cy - ty) * scale) / oldScale;
+          var u = userSpacePoint(svg, e);
+          tx = u.x - ((u.x - tx) * scale) / oldScale;
+          ty = u.y - ((u.y - ty) * scale) / oldScale;
         }
         apply();
       },
       { passive: false },
     );
 
-    // Arrow-key pan and +/- zoom when the canvas itself is focused
-    // (the SVG element has tabindex="0" from the SSR template).
+    // Arrow-key pan and +/- zoom via keyboard. Translation step is in
+    // user-space units (matches the viewBox) so behaviour scales the
+    // same regardless of the SVG's pixel size on screen.
     svg.addEventListener("keydown", function (e) {
       var step = 32;
       switch (e.key) {
@@ -172,18 +234,6 @@
           apply();
           e.preventDefault();
           break;
-        case "+":
-        case "=":
-          scale = Math.min(3, scale * 1.1);
-          apply();
-          e.preventDefault();
-          break;
-        case "-":
-        case "_":
-          scale = Math.max(0.3, scale / 1.1);
-          apply();
-          e.preventDefault();
-          break;
       }
     });
   }
@@ -194,32 +244,44 @@
       if (!node) return;
       var dn = node.getAttribute("data-dn");
       var type = node.getAttribute("data-type");
-      var expandable = node.getAttribute("data-expandable") === "true";
+      var expandable = node.getAttribute("data-expandable");
       var clickedBadge = !!e.target.closest(".graph-node__expand-badge");
 
-      if (expandable && clickedBadge) {
+      if (clickedBadge && expandable === "true") {
         expandNode(dn, state, svg);
+      } else if (clickedBadge && expandable === "expanded") {
+        collapseNode(dn, state, svg);
       } else {
         pivotToDrawer(dn, type);
       }
     });
     // Keyboard parity with mouse: Enter pivots (matches the SSR
     // aria-label "Press Enter to open"), and +/= expands when the node
-    // is expandable. Space is intentionally not bound — convention on
-    // non-form elements is page-down, not activation.
+    // is expandable, -/_ collapses when already expanded. Space is
+    // intentionally not bound — convention on non-form elements is
+    // page-down, not activation.
     svg.addEventListener("keydown", function (e) {
       var node = e.target.closest(".graph-node");
       if (!node) return;
       var dn = node.getAttribute("data-dn");
       var type = node.getAttribute("data-type");
-      var expandable = node.getAttribute("data-expandable") === "true";
+      var expandable = node.getAttribute("data-expandable");
 
       if (e.key === "Enter") {
         e.preventDefault();
         pivotToDrawer(dn, type);
-      } else if (expandable && (e.key === "+" || e.key === "=")) {
+      } else if (
+        (e.key === "+" || e.key === "=") &&
+        expandable === "true"
+      ) {
         e.preventDefault();
         expandNode(dn, state, svg);
+      } else if (
+        (e.key === "-" || e.key === "_") &&
+        expandable === "expanded"
+      ) {
+        e.preventDefault();
+        collapseNode(dn, state, svg);
       }
     });
   }
@@ -235,9 +297,6 @@
     window.location.href = base + encodeURIComponent(dn);
   }
 
-  // announce updates the off-screen aria-live region so SR users hear
-  // expansion results. Clear-then-set forces re-announcement when the
-  // same message fires twice.
   function announce(msg) {
     var el = document.getElementById("graph-announce");
     if (el) {
@@ -248,15 +307,46 @@
     }
   }
 
+  // setBadge replaces a node's expand-badge between "+" (expandable),
+  // "-" (expanded — collapse possible), and removed (terminal node).
+  // Returns the new badge element or null.
+  function setBadge(nodeEl, kind) {
+    var existing = nodeEl.querySelector(".graph-node__expand-badge");
+    if (existing) existing.remove();
+    if (kind !== "+" && kind !== "-") return null;
+    var ns = "http://www.w3.org/2000/svg";
+    var badge = document.createElementNS(ns, "g");
+    badge.setAttribute("class", "graph-node__expand-badge");
+    badge.setAttribute("transform", "translate(18,-18)");
+    badge.setAttribute("aria-hidden", "true");
+    var bg = document.createElementNS(ns, "circle");
+    bg.setAttribute("r", "8");
+    bg.setAttribute("class", "graph-node__expand-badge-bg");
+    badge.appendChild(bg);
+    var mark = document.createElementNS(ns, "text");
+    mark.setAttribute("text-anchor", "middle");
+    mark.setAttribute("y", "3");
+    mark.setAttribute("class", "graph-node__expand-badge-mark");
+    mark.textContent = kind;
+    badge.appendChild(mark);
+    nodeEl.appendChild(badge);
+    return badge;
+  }
+
+  // refreshLabel rebuilds the aria-label for a node based on the
+  // current data-expandable state ("true"/"expanded"/"false").
+  function refreshLabel(nodeEl) {
+    var label = nodeEl.getAttribute("aria-label") || "";
+    var cut = label.indexOf(" Press Enter");
+    if (cut !== -1) label = label.substring(0, cut);
+    label += labelHint(nodeEl.getAttribute("data-expandable"));
+    nodeEl.setAttribute("aria-label", label);
+  }
+
   function expandNode(dn, state, svg) {
-    var url =
-      "/api/graph.json?entity=" + encodeURIComponent(dn) + "&depth=1";
+    var url = "/api/graph.json?entity=" + encodeURIComponent(dn) + "&depth=1";
     fetch(url, { credentials: "same-origin" })
       .then(function (r) {
-        // Surface non-2xx (401 redirect to login, 404 missing entity,
-        // 500 server error) as thrown errors so the .catch below can
-        // announce them — otherwise r.json() would parse the HTML
-        // error body and throw a confusing SyntaxError instead.
         if (!r.ok) throw new Error("graph expand HTTP " + r.status);
         return r.json();
       })
@@ -267,12 +357,14 @@
         state.nodes.forEach(function (n) {
           existingDNs[n.dn] = true;
         });
+        var parent = state.nodes.find(function (x) {
+          return x.dn === dn;
+        });
+        var parentRing = parent ? parent.ring : 1;
         data.nodes.forEach(function (n) {
           if (existingDNs[n.dn]) return;
-          var parent = state.nodes.find(function (x) {
-            return x.dn === dn;
-          });
-          n.ring = (parent && parent.ring + 1) || 2;
+          n.ring = parentRing + 1;
+          n.addedBy = dn;
           state.nodes.push(n);
           renderNode(svg, n);
           affectedRings[n.ring] = true;
@@ -287,41 +379,105 @@
             );
           });
           if (!dup) {
+            e.addedBy = dn;
             state.edges.push(e);
             renderEdge(svg, e, state.nodes);
           }
         });
-        // Re-distribute angles on each ring that gained a node. Without
-        // this, expanded nodes keep the angles the backend assigned in
-        // the depth=1 ego graph (centred on the clicked node) — which
-        // were computed for a different node set and overlap or cluster
-        // oddly when merged into the original layout.
         Object.keys(affectedRings).forEach(function (r) {
           reLayoutRing(svg, state, parseInt(r, 10));
         });
-        // Mark clicked node as non-expandable so a subsequent click
-        // pivots to the drawer instead of re-fetching.
+        // Switch the parent's badge to "-" (collapse) and update its
+        // aria-label so SR users hear the new affordance.
         var el = svg.querySelector(
           '.graph-node[data-dn="' + CSS.escape(dn) + '"]',
         );
         if (el) {
-          el.setAttribute("data-expandable", "false");
-          var badge = el.querySelector(".graph-node__expand-badge");
-          if (badge) badge.remove();
+          el.setAttribute("data-expandable", "expanded");
+          setBadge(el, "-");
+          refreshLabel(el);
         }
         announce("Expanded " + dn + ": added " + added + " nodes.");
       })
       .catch(function (err) {
-        // Without this the badge stays clickable forever and SR users
-        // hear nothing. Trace + announce so the operator can retry.
         console.error("graph expand failed", err);
         announce("Expand failed.");
       });
   }
 
+  // collapseNode removes every node and edge that was added when this
+  // parent was expanded, restores the "+" badge so the user can
+  // re-expand, and re-lays out any rings that lost members.
+  function collapseNode(dn, state, svg) {
+    var removedDNs = {};
+    var affectedRings = {};
+    // Collect descendants: a node is in the collapse set if it (or one
+    // of its ancestors transitively) was addedBy the clicked dn.
+    var queue = [dn];
+    var ancestors = {};
+    ancestors[dn] = true;
+    while (queue.length > 0) {
+      var head = queue.shift();
+      state.nodes.forEach(function (n) {
+        if (n.addedBy === head && !ancestors[n.dn]) {
+          ancestors[n.dn] = true;
+          removedDNs[n.dn] = true;
+          affectedRings[n.ring] = true;
+          queue.push(n.dn);
+        }
+      });
+    }
+    // Drop nodes from state + DOM.
+    state.nodes = state.nodes.filter(function (n) {
+      if (!removedDNs[n.dn]) return true;
+      var el = svg.querySelector(
+        '.graph-node[data-dn="' + CSS.escape(n.dn) + '"]',
+      );
+      if (el) el.remove();
+      return false;
+    });
+    // Drop edges whose endpoints are removed OR which were addedBy the
+    // collapsed parent (covers parent→child edges where the child
+    // survives but the relationship was introduced by this expansion).
+    state.edges = state.edges.filter(function (e) {
+      var keep =
+        !removedDNs[e.source] && !removedDNs[e.target] && e.addedBy !== dn;
+      if (keep) return true;
+      var line = svg.querySelector(
+        'line[data-source="' +
+          CSS.escape(e.source) +
+          '"][data-target="' +
+          CSS.escape(e.target) +
+          '"]',
+      );
+      if (line) line.remove();
+      return false;
+    });
+    Object.keys(affectedRings).forEach(function (r) {
+      reLayoutRing(svg, state, parseInt(r, 10));
+    });
+    // Restore the parent's "+" badge and aria-label.
+    var parentEl = svg.querySelector(
+      '.graph-node[data-dn="' + CSS.escape(dn) + '"]',
+    );
+    if (parentEl) {
+      parentEl.setAttribute("data-expandable", "true");
+      setBadge(parentEl, "+");
+      refreshLabel(parentEl);
+    }
+    announce(
+      "Collapsed " +
+        dn +
+        ": removed " +
+        Object.keys(removedDNs).length +
+        " nodes.",
+    );
+  }
+
   // reLayoutRing redistributes nodes on a ring evenly around the circle
   // and re-routes any edges touching them. Called after expandNode
-  // merges new nodes onto an existing ring.
+  // merges new nodes onto an existing ring or collapseNode removes
+  // some.
   function reLayoutRing(svg, state, ring) {
     var ringNodes = state.nodes.filter(function (n) {
       return n.ring === ring;
@@ -343,7 +499,6 @@
       );
       if (el) el.setAttribute("transform", "translate(" + x + "," + y + ")");
     });
-    // Re-route edges touching any moved node on this ring.
     state.edges.forEach(function (e) {
       var src = state.nodes.find(function (x) {
         return x.dn === e.source;
@@ -372,12 +527,20 @@
     });
   }
 
+  // discRadius scales node disc size with degree so high-connectivity
+  // nodes (e.g. groups with many members) read as visually weightier.
+  // Capped so the max never exceeds ~1.4x the base — beyond that
+  // overlapping discs become unreadable.
+  function discRadius(degree) {
+    var base = 22;
+    var step = 1.5;
+    var max = 32;
+    return Math.min(max, base + (degree || 0) * step);
+  }
+
   function renderNode(svg, n) {
     var ns = "http://www.w3.org/2000/svg";
     var viewport = svg.querySelector(".graph-viewport");
-    // Match the SSR concentricXY radius multiplier (graph_v2.templ
-    // uses 150 so ring-3 nodes — including the 28-radius disc and
-    // expand-badge — fit inside the ±500 viewBox).
     var r = n.ring * 150;
     var x = r * Math.cos(n.angle),
       y = r * Math.sin(n.angle);
@@ -391,16 +554,14 @@
     g.setAttribute("role", "button");
     g.setAttribute("data-dn", n.dn);
     g.setAttribute("data-type", n.type);
-    g.setAttribute("data-expandable", String(!!n.expandable));
-    // Mirror activateNodes(): build the same "<typed label>. Press
-    // Enter to open. [Press + to expand more relations.]" hint stack
-    // so newly inserted nodes carry full screen-reader context.
+    g.setAttribute("data-expandable", n.expandable ? "true" : "false");
     var base = nodeLabel(n);
-    var hint = " Press Enter to open.";
-    if (n.expandable) hint += " Press + to expand more relations.";
-    g.setAttribute("aria-label", base + hint);
+    g.setAttribute(
+      "aria-label",
+      base + labelHint(n.expandable ? "true" : "false"),
+    );
     var circ = document.createElementNS(ns, "circle");
-    circ.setAttribute("r", "28");
+    circ.setAttribute("r", String(discRadius(n.degree)));
     circ.setAttribute("class", "graph-node__disc");
     g.appendChild(circ);
     var text = document.createElementNS(ns, "text");
@@ -409,27 +570,7 @@
     text.setAttribute("class", "graph-node__label");
     text.textContent = n.label;
     g.appendChild(text);
-    // Mirror the SSR template's expand-badge (graph_v2.templ graphNode):
-    // without it, freshly-fetched expandable children can be pivoted but
-    // never further expanded by mouse — wireNodeClicks requires a click
-    // on .graph-node__expand-badge to trigger expansion.
-    if (n.expandable) {
-      var badge = document.createElementNS(ns, "g");
-      badge.setAttribute("class", "graph-node__expand-badge");
-      badge.setAttribute("transform", "translate(18,-18)");
-      badge.setAttribute("aria-hidden", "true");
-      var bbg = document.createElementNS(ns, "circle");
-      bbg.setAttribute("r", "8");
-      bbg.setAttribute("class", "graph-node__expand-badge-bg");
-      badge.appendChild(bbg);
-      var bmark = document.createElementNS(ns, "text");
-      bmark.setAttribute("text-anchor", "middle");
-      bmark.setAttribute("y", "3");
-      bmark.setAttribute("class", "graph-node__expand-badge-mark");
-      bmark.textContent = "+";
-      badge.appendChild(bmark);
-      g.appendChild(badge);
-    }
+    if (n.expandable) setBadge(g, "+");
     viewport.appendChild(g);
   }
 
@@ -454,17 +595,13 @@
     line.setAttribute("y2", t[1]);
     line.setAttribute("data-source", e.source);
     line.setAttribute("data-target", e.target);
-    // Insert at the front so the edge sits behind nodes in z-order.
     viewport.insertBefore(line, viewport.firstChild);
   }
+
   function wireDepthSlider() {
     var slider = document.querySelector("[data-graph-slider]");
     if (!slider) return;
     var out = document.querySelector(".graph-slider__value");
-    // 'input' fires per-step while the user drags; 'change' fires on
-    // release. Use 'input' for the live value display and 'change' to
-    // submit the form, so a drag from 1→3 produces one navigation,
-    // not three.
     slider.addEventListener("input", function () {
       if (out) out.textContent = slider.value;
     });

--- a/internal/web/static/js/v2-graph.js
+++ b/internal/web/static/js/v2-graph.js
@@ -387,6 +387,7 @@
         Object.keys(affectedRings).forEach(function (r) {
           reLayoutRing(svg, state, parseInt(r, 10));
         });
+        recomputeDegrees(state, svg);
         // Switch the parent's badge to "-" (collapse) and update its
         // aria-label so SR users hear the new affordance.
         var el = svg.querySelector(
@@ -436,12 +437,17 @@
       if (el) el.remove();
       return false;
     });
-    // Drop edges whose endpoints are removed OR which were addedBy the
-    // collapsed parent (covers parent→child edges where the child
-    // survives but the relationship was introduced by this expansion).
+    // Drop edges whose endpoints are removed, OR whose addedBy points
+    // to the collapsed parent or any of its transitive descendants.
+    // The transitive case covers edges introduced by a sub-expansion
+    // that connect two nodes that survive the collapse — without the
+    // ancestors check those edges would orphan after collapse.
     state.edges = state.edges.filter(function (e) {
       var keep =
-        !removedDNs[e.source] && !removedDNs[e.target] && e.addedBy !== dn;
+        !removedDNs[e.source] &&
+        !removedDNs[e.target] &&
+        e.addedBy !== dn &&
+        !ancestors[e.addedBy];
       if (keep) return true;
       var line = svg.querySelector(
         'line[data-source="' +
@@ -456,6 +462,7 @@
     Object.keys(affectedRings).forEach(function (r) {
       reLayoutRing(svg, state, parseInt(r, 10));
     });
+    recomputeDegrees(state, svg);
     // Restore the parent's "+" badge and aria-label.
     var parentEl = svg.querySelector(
       '.graph-node[data-dn="' + CSS.escape(dn) + '"]',
@@ -531,11 +538,37 @@
   // nodes (e.g. groups with many members) read as visually weightier.
   // Capped so the max never exceeds ~1.4x the base — beyond that
   // overlapping discs become unreadable.
+  //
+  // Math.round mirrors the Go-side discRadius() in graph_v2.templ
+  // (which truncates to int) so SSR-rendered and JS-rendered nodes
+  // share the same radius for the same degree.
   function discRadius(degree) {
     var base = 22;
     var step = 1.5;
     var max = 32;
-    return Math.min(max, base + (degree || 0) * step);
+    return Math.min(max, Math.round(base + (degree || 0) * step));
+  }
+
+  // recomputeDegrees walks state.edges, refreshes each node's degree
+  // count, and updates the rendered <circle r="..."> attribute so disc
+  // sizing stays in sync with the actual edge set after expand or
+  // collapse. Without this, a hub that gains/loses memberships keeps
+  // its old radius and the weighted layout misrepresents reality.
+  function recomputeDegrees(state, svg) {
+    var deg = {};
+    state.edges.forEach(function (e) {
+      deg[e.source] = (deg[e.source] || 0) + 1;
+      deg[e.target] = (deg[e.target] || 0) + 1;
+    });
+    state.nodes.forEach(function (n) {
+      var newDegree = deg[n.dn] || 0;
+      if (n.degree === newDegree) return;
+      n.degree = newDegree;
+      var el = svg.querySelector(
+        '.graph-node[data-dn="' + CSS.escape(n.dn) + '"] .graph-node__disc',
+      );
+      if (el) el.setAttribute("r", String(discRadius(newDegree)));
+    });
   }
 
   function renderNode(svg, n) {

--- a/internal/web/template_cache.go
+++ b/internal/web/template_cache.go
@@ -82,6 +82,15 @@ func (tc *TemplateCache) generateCacheKey(c *fiber.Ctx, additionalData ...string
 		h.Write([]byte(userDN))
 	}
 
+	// Include the list-view preference cookie so /users (no query) with
+	// graph-view=table caches separately from /users with graph-view=list.
+	// Without this, the first cached response wins regardless of the
+	// per-user preference and the segmented toggle appears broken.
+	if v := c.Cookies(graphViewCookie); v != "" {
+		h.Write([]byte("view:"))
+		h.Write([]byte(v))
+	}
+
 	// Include any additional data for cache differentiation
 	for _, data := range additionalData {
 		h.Write([]byte(data))

--- a/internal/web/templates/computers_v2.templ
+++ b/internal/web/templates/computers_v2.templ
@@ -33,7 +33,7 @@ templ ComputersListV2(computers []ldap.Computer, ouFilter string, ous []string, 
 					<p class="list-page__count">{ fmt.Sprintf("%d", len(computers)) } computers</p>
 				</div>
 				<div class="list-page__head-controls">
-					@listGraphToggle("/computers", currentView, computersFilterQS(ouFilter))
+					@listGraphToggle("/computers", currentView, ComputersFilterQS(ouFilter))
 				</div>
 			</header>
 
@@ -394,11 +394,11 @@ func clearComputersOUHref() templ.SafeURL {
 	return templ.URL("/computers")
 }
 
-// computersFilterQS encodes the active /computers filter combination as a
+// ComputersFilterQS encodes the active /computers filter combination as a
 // bare query string (no leading "?", no view selector). Used by the
 // listGraphToggle to preserve filters when switching between
 // list / graph segments.
-func computersFilterQS(ouFilter string) string {
+func ComputersFilterQS(ouFilter string) string {
 	v := url.Values{}
 	if ouFilter != "" {
 		v.Set("ou", ouFilter)

--- a/internal/web/templates/computers_v2.templ
+++ b/internal/web/templates/computers_v2.templ
@@ -28,9 +28,13 @@ templ ComputersListV2(computers []ldap.Computer, ouFilter string, ous []string, 
 
 		<main id="main-content" class="list-page" data-bulk-scope="computers">
 			<header class="list-page__head">
-				<h1 class="list-page__title">Computers</h1>
-				<p class="list-page__count">{ fmt.Sprintf("%d", len(computers)) } computers</p>
-				@listGraphToggle("/computers", currentView, computersFilterQS(ouFilter))
+				<div class="list-page__head-titles">
+					<h1 class="list-page__title">Computers</h1>
+					<p class="list-page__count">{ fmt.Sprintf("%d", len(computers)) } computers</p>
+				</div>
+				<div class="list-page__head-controls">
+					@listGraphToggle("/computers", currentView, computersFilterQS(ouFilter))
+				</div>
 			</header>
 
 			@listFlashes(flashes)

--- a/internal/web/templates/graph_toggle.templ
+++ b/internal/web/templates/graph_toggle.templ
@@ -1,21 +1,29 @@
-// internal/web/templates/graph_toggle.templ — segmented "List | Graph"
-// view toggle reused by all three list pages (Phase 3 §6.6).
+// internal/web/templates/graph_toggle.templ — segmented "List | Table | Graph"
+// view toggle reused by all three list pages.
 package templates
 
 import "strings"
 
-// listGraphToggle renders the segmented control. `base` is the bare list
-// route ("/users", "/groups", "/computers"). `currentView` is the value
-// of c.Query("view") at request time (empty string for default list).
-// `filters` is the URL-encoded query string of OTHER filters to preserve
-// (without leading "?", without view=…). Both branches preserve filters.
+// listGraphToggle renders the segmented control for switching between
+// the three list-page views. `base` is the bare list route ("/users",
+// "/groups", "/computers"). `currentView` is the value returned by
+// pickView (one of "list", "table", "graph"). `filters` is the URL-
+// encoded query string of OTHER filters to preserve (without leading
+// "?", without view=…). All segments include an explicit ?view= so
+// clicking re-asserts the user's choice and (server-side) refreshes
+// the persistence cookie.
 templ listGraphToggle(base, currentView, filters string) {
-	<nav class="graph-segmented" aria-label="List or graph view">
+	<nav class="graph-segmented" aria-label="List, table, or graph view">
 		<a
-			class={ "graph-segmented__option", toggleClass(currentView, "") }
-			href={ templ.URL(buildToggleHref(base, "", filters)) }
-			aria-current={ toggleAriaCurrent(currentView, "") }
+			class={ "graph-segmented__option", toggleClass(currentView, "list") }
+			href={ templ.URL(buildToggleHref(base, "list", filters)) }
+			aria-current={ toggleAriaCurrent(currentView, "list") }
 		>List</a>
+		<a
+			class={ "graph-segmented__option", toggleClass(currentView, "table") }
+			href={ templ.URL(buildToggleHref(base, "table", filters)) }
+			aria-current={ toggleAriaCurrent(currentView, "table") }
+		>Table</a>
 		<a
 			class={ "graph-segmented__option", toggleClass(currentView, "graph") }
 			href={ templ.URL(buildToggleHref(base, "graph", filters)) }
@@ -49,20 +57,14 @@ func toggleAriaCurrent(current, target string) string {
 	return "false"
 }
 
-// buildToggleHref combines base path + view selector + preserved filters.
-// "view=graph" goes first when set; other filter pairs follow.
+// buildToggleHref combines base path + view selector + preserved
+// filters. The view selector is always emitted so the server's
+// pickView() helper can refresh its persistence cookie even when the
+// user clicks the segment that's already active.
 func buildToggleHref(base, view, filters string) string {
-	parts := []string{}
-	if view != "" {
-		parts = append(parts, "view="+view)
-	}
-
+	parts := []string{"view=" + view}
 	if filters != "" {
 		parts = append(parts, filters)
-	}
-
-	if len(parts) == 0 {
-		return base
 	}
 
 	return base + "?" + strings.Join(parts, "&")

--- a/internal/web/templates/graph_v2.templ
+++ b/internal/web/templates/graph_v2.templ
@@ -37,12 +37,21 @@ templ GraphPageV2(vm GraphPageVM) {
 	@baseV2PageScroll(graphTitle(vm)) {
 		@topnavV2("/graph")
 		<main id="main-content" class="graph-page">
-			<header class="graph-page__head">
-				<h1 class="graph-page__title">{ graphTitle(vm) }</h1>
-				if vm.BackHref != "" {
-					@listGraphToggle(vm.BackHref, "graph", "")
-				}
-				@graphDepthSlider(vm.Data.Depth, vm.Data.Focus)
+			<header class="list-page__head">
+				<div class="list-page__head-titles">
+					<h1 class="list-page__title">{ graphTitle(vm) }</h1>
+					if vm.Data.Overflow.Truncated {
+						<p class="list-page__count">
+							{ fmt.Sprintf("%d of %d", vm.Data.Overflow.Rendered, vm.Data.Overflow.Available) }
+						</p>
+					}
+				</div>
+				<div class="list-page__head-controls">
+					@graphDepthSlider(vm.Data.Depth, vm.Data.Focus)
+					if vm.BackHref != "" {
+						@listGraphToggle(vm.BackHref, "graph", "")
+					}
+				</div>
 			</header>
 			if vm.Data.Overflow.Truncated {
 				<p class="graph-page__overflow" role="status">

--- a/internal/web/templates/graph_v2.templ
+++ b/internal/web/templates/graph_v2.templ
@@ -24,6 +24,7 @@ type GraphPageVM struct {
 	SortTo     string
 	SortType   string
 	BackHref   string // URL to return to the referring list/detail page
+	FilterQS   string // url.Values-encoded query string of preserved filters (without leading "?", without "view=") — used by the List|Table|Graph toggle so switching views keeps the same subset
 }
 
 // GraphPageV2 renders the /graph page. The page works without
@@ -49,7 +50,7 @@ templ GraphPageV2(vm GraphPageVM) {
 				<div class="list-page__head-controls">
 					@graphDepthSlider(vm.Data.Depth, vm.Data.Focus)
 					if vm.BackHref != "" {
-						@listGraphToggle(vm.BackHref, "graph", "")
+						@listGraphToggle(vm.BackHref, "graph", vm.FilterQS)
 					}
 				</div>
 			</header>
@@ -213,8 +214,9 @@ func nodeXY(dn string, nodes []ldap_cache.Node) (float64, float64) {
 
 // discRadius scales node disc size with degree so high-connectivity
 // nodes (groups with many members, hub users) read as visually
-// weightier. Mirrors the JS-side discRadius() in v2-graph.js — keep
-// the formulas in sync.
+// weightier. Mirrors the JS-side discRadius() in v2-graph.js — both
+// use math.Round / Math.round so SSR-rendered and JS-rendered nodes
+// share the same radius for the same degree.
 func discRadius(degree int) int {
 	const (
 		base = 22
@@ -222,7 +224,7 @@ func discRadius(degree int) int {
 		maxR = 32
 	)
 
-	r := base + int(float64(degree)*step)
+	r := int(math.Round(base + float64(degree)*step))
 	if r > maxR {
 		return maxR
 	}

--- a/internal/web/templates/graph_v2.templ
+++ b/internal/web/templates/graph_v2.templ
@@ -34,7 +34,7 @@ type GraphPageVM struct {
 // script (v2-graph.js, Slice 4) can read it without a second fetch.
 // Slice 4 will read it via document.getElementById('graph-data').content.textContent.
 templ GraphPageV2(vm GraphPageVM) {
-	@baseV2(graphTitle(vm)) {
+	@baseV2PageScroll(graphTitle(vm)) {
 		@topnavV2("/graph")
 		<main id="main-content" class="graph-page">
 			<header class="graph-page__head">
@@ -164,7 +164,7 @@ templ graphNode(n ldap_cache.Node) {
 		data-expandable={ fmt.Sprintf("%t", n.Expandable) }
 		aria-label={ graphNodeLabel(n) }
 	>
-		<circle r="28" class="graph-node__disc"></circle>
+		<circle r={ fmt.Sprintf("%d", discRadius(n.Degree)) } class="graph-node__disc"></circle>
 		<text class="graph-node__label" text-anchor="middle" y="4">{ n.Label }</text>
 		if n.Expandable {
 			<g class="graph-node__expand-badge" transform="translate(18,-18)" aria-hidden="true">
@@ -200,6 +200,25 @@ func nodeXY(dn string, nodes []ldap_cache.Node) (float64, float64) {
 	}
 
 	return 0, 0
+}
+
+// discRadius scales node disc size with degree so high-connectivity
+// nodes (groups with many members, hub users) read as visually
+// weightier. Mirrors the JS-side discRadius() in v2-graph.js — keep
+// the formulas in sync.
+func discRadius(degree int) int {
+	const (
+		base = 22
+		step = 1.5
+		maxR = 32
+	)
+
+	r := base + int(float64(degree)*step)
+	if r > maxR {
+		return maxR
+	}
+
+	return r
 }
 
 // graphNodeLabel composes the screen-reader label for a node. Includes

--- a/internal/web/templates/groups_v2.templ
+++ b/internal/web/templates/groups_v2.templ
@@ -37,9 +37,13 @@ templ GroupsListV2(groups []ldap.Group, ouFilter, memberDN, memberCN string, ous
 
 		<main id="main-content" class="list-page" data-bulk-scope="groups">
 			<header class="list-page__head">
-				<h1 class="list-page__title">Groups</h1>
-				<p class="list-page__count">{ fmt.Sprintf("%d", len(groups)) } groups</p>
-				@listGraphToggle("/groups", currentView, groupsFilterQS(ouFilter, memberDN))
+				<div class="list-page__head-titles">
+					<h1 class="list-page__title">Groups</h1>
+					<p class="list-page__count">{ fmt.Sprintf("%d", len(groups)) } groups</p>
+				</div>
+				<div class="list-page__head-controls">
+					@listGraphToggle("/groups", currentView, groupsFilterQS(ouFilter, memberDN))
+				</div>
 			</header>
 
 			@listFlashes(flashes)

--- a/internal/web/templates/groups_v2.templ
+++ b/internal/web/templates/groups_v2.templ
@@ -42,7 +42,7 @@ templ GroupsListV2(groups []ldap.Group, ouFilter, memberDN, memberCN string, ous
 					<p class="list-page__count">{ fmt.Sprintf("%d", len(groups)) } groups</p>
 				</div>
 				<div class="list-page__head-controls">
-					@listGraphToggle("/groups", currentView, groupsFilterQS(ouFilter, memberDN))
+					@listGraphToggle("/groups", currentView, GroupsFilterQS(ouFilter, memberDN))
 				</div>
 			</header>
 
@@ -651,11 +651,11 @@ templ groupAddUserForm(vm GroupDrawerVM) {
 	}
 }
 
-// groupsFilterQS encodes the active /groups filter combination as a bare
+// GroupsFilterQS encodes the active /groups filter combination as a bare
 // query string (no leading "?", no view selector). Used by the
 // listGraphToggle to preserve filters when switching between
 // list / graph segments.
-func groupsFilterQS(ouFilter, memberDN string) string {
+func GroupsFilterQS(ouFilter, memberDN string) string {
 	v := url.Values{}
 	if ouFilter != "" {
 		v.Set("ou", ouFilter)

--- a/internal/web/templates/list_table_v2.templ
+++ b/internal/web/templates/list_table_v2.templ
@@ -15,7 +15,7 @@ import (
 )
 
 // UsersListTableV2 renders the full-width users table.
-templ UsersListTableV2(users []ldap.User, currentView string, flashes []Flash, palettePinned []PinnedEntry) {
+templ UsersListTableV2(users []ldap.User, currentView, filterQS string, flashes []Flash, palettePinned []PinnedEntry) {
 	@baseV2PageScroll("Users — Table") {
 		@topnavV2("/users")
 		<main id="main-content" class="list-table-page">
@@ -25,7 +25,7 @@ templ UsersListTableV2(users []ldap.User, currentView string, flashes []Flash, p
 					<p class="list-page__count">{ fmt.Sprintf("%d users", len(users)) }</p>
 				</div>
 				<div class="list-page__head-controls">
-					@listGraphToggle("/users", currentView, "")
+					@listGraphToggle("/users", currentView, filterQS)
 				</div>
 			</header>
 			@listFlashes(flashes)
@@ -55,7 +55,7 @@ templ UsersListTableV2(users []ldap.User, currentView string, flashes []Flash, p
 }
 
 // GroupsListTableV2 renders the full-width groups table.
-templ GroupsListTableV2(groups []ldap.Group, currentView string, flashes []Flash, palettePinned []PinnedEntry) {
+templ GroupsListTableV2(groups []ldap.Group, currentView, filterQS string, flashes []Flash, palettePinned []PinnedEntry) {
 	@baseV2PageScroll("Groups — Table") {
 		@topnavV2("/groups")
 		<main id="main-content" class="list-table-page">
@@ -65,7 +65,7 @@ templ GroupsListTableV2(groups []ldap.Group, currentView string, flashes []Flash
 					<p class="list-page__count">{ fmt.Sprintf("%d groups", len(groups)) }</p>
 				</div>
 				<div class="list-page__head-controls">
-					@listGraphToggle("/groups", currentView, "")
+					@listGraphToggle("/groups", currentView, filterQS)
 				</div>
 			</header>
 			@listFlashes(flashes)
@@ -93,7 +93,7 @@ templ GroupsListTableV2(groups []ldap.Group, currentView string, flashes []Flash
 }
 
 // ComputersListTableV2 renders the full-width computers table.
-templ ComputersListTableV2(computers []ldap.Computer, currentView string, flashes []Flash, palettePinned []PinnedEntry) {
+templ ComputersListTableV2(computers []ldap.Computer, currentView, filterQS string, flashes []Flash, palettePinned []PinnedEntry) {
 	@baseV2PageScroll("Computers — Table") {
 		@topnavV2("/computers")
 		<main id="main-content" class="list-table-page">
@@ -103,7 +103,7 @@ templ ComputersListTableV2(computers []ldap.Computer, currentView string, flashe
 					<p class="list-page__count">{ fmt.Sprintf("%d computers", len(computers)) }</p>
 				</div>
 				<div class="list-page__head-controls">
-					@listGraphToggle("/computers", currentView, "")
+					@listGraphToggle("/computers", currentView, filterQS)
 				</div>
 			</header>
 			@listFlashes(flashes)

--- a/internal/web/templates/list_table_v2.templ
+++ b/internal/web/templates/list_table_v2.templ
@@ -1,0 +1,151 @@
+// internal/web/templates/list_table_v2.templ — full-width "Table"
+// view for /users, /groups, /computers. Companion to UsersListV2 /
+// GroupsListV2 / ComputersListV2 (List view) and GraphPageV2 (Graph
+// view). The third option in the segmented toggle.
+//
+// Goal: scan many rows fast. No filter rail, no drawer. Each row links
+// directly to the entity's detail page — clicking goes "all the way",
+// not into a side pane.
+package templates
+
+import (
+	"fmt"
+
+	ldap "github.com/netresearch/simple-ldap-go"
+)
+
+// UsersListTableV2 renders the full-width users table.
+templ UsersListTableV2(users []ldap.User, currentView string, flashes []Flash, palettePinned []PinnedEntry) {
+	@baseV2PageScroll("Users — Table") {
+		@topnavV2("/users")
+		<main id="main-content" class="list-table-page">
+			<header class="list-page__head">
+				<div class="list-page__head-titles">
+					<h1 class="list-page__title">Users</h1>
+					<p class="list-page__count">{ fmt.Sprintf("%d users", len(users)) }</p>
+				</div>
+				<div class="list-page__head-controls">
+					@listGraphToggle("/users", currentView, "")
+				</div>
+			</header>
+			@listFlashes(flashes)
+			<table class="list-table">
+				<thead>
+					<tr>
+						<th scope="col">CN</th>
+						<th scope="col">SAM account</th>
+						<th scope="col">Mail</th>
+						<th scope="col">Status</th>
+					</tr>
+				</thead>
+				<tbody>
+					for _, u := range users {
+						<tr>
+							<td><a class="list-table__link" href={ userDetailHref(u) }>{ u.CN() }</a></td>
+							<td>{ u.SAMAccountName }</td>
+							<td>{ derefString(u.Mail) }</td>
+							<td>{ userStatusLabel(u) }</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+			@paletteV2WithPinned(palettePinned)
+		</main>
+	}
+}
+
+// GroupsListTableV2 renders the full-width groups table.
+templ GroupsListTableV2(groups []ldap.Group, currentView string, flashes []Flash, palettePinned []PinnedEntry) {
+	@baseV2PageScroll("Groups — Table") {
+		@topnavV2("/groups")
+		<main id="main-content" class="list-table-page">
+			<header class="list-page__head">
+				<div class="list-page__head-titles">
+					<h1 class="list-page__title">Groups</h1>
+					<p class="list-page__count">{ fmt.Sprintf("%d groups", len(groups)) }</p>
+				</div>
+				<div class="list-page__head-controls">
+					@listGraphToggle("/groups", currentView, "")
+				</div>
+			</header>
+			@listFlashes(flashes)
+			<table class="list-table">
+				<thead>
+					<tr>
+						<th scope="col">CN</th>
+						<th scope="col">Members</th>
+						<th scope="col">DN</th>
+					</tr>
+				</thead>
+				<tbody>
+					for _, g := range groups {
+						<tr>
+							<td><a class="list-table__link" href={ groupDetailHref(g) }>{ g.CN() }</a></td>
+							<td class="list-table__num">{ fmt.Sprintf("%d", len(g.Members)) }</td>
+							<td class="list-table__dn">{ g.DN() }</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+			@paletteV2WithPinned(palettePinned)
+		</main>
+	}
+}
+
+// ComputersListTableV2 renders the full-width computers table.
+templ ComputersListTableV2(computers []ldap.Computer, currentView string, flashes []Flash, palettePinned []PinnedEntry) {
+	@baseV2PageScroll("Computers — Table") {
+		@topnavV2("/computers")
+		<main id="main-content" class="list-table-page">
+			<header class="list-page__head">
+				<div class="list-page__head-titles">
+					<h1 class="list-page__title">Computers</h1>
+					<p class="list-page__count">{ fmt.Sprintf("%d computers", len(computers)) }</p>
+				</div>
+				<div class="list-page__head-controls">
+					@listGraphToggle("/computers", currentView, "")
+				</div>
+			</header>
+			@listFlashes(flashes)
+			<table class="list-table">
+				<thead>
+					<tr>
+						<th scope="col">CN</th>
+						<th scope="col">SAM account</th>
+						<th scope="col">Status</th>
+						<th scope="col">DN</th>
+					</tr>
+				</thead>
+				<tbody>
+					for _, c := range computers {
+						<tr>
+							<td><a class="list-table__link" href={ computerDetailHref(c) }>{ c.CN() }</a></td>
+							<td>{ c.SAMAccountName }</td>
+							<td>{ computerStatusLabel(c) }</td>
+							<td class="list-table__dn">{ c.DN() }</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+			@paletteV2WithPinned(palettePinned)
+		</main>
+	}
+}
+
+// userStatusLabel — "Enabled" / "Disabled" cell content.
+func userStatusLabel(u ldap.User) string {
+	if u.Enabled {
+		return "Enabled"
+	}
+
+	return "Disabled"
+}
+
+// computerStatusLabel — "Enabled" / "Disabled" cell content.
+func computerStatusLabel(c ldap.Computer) string {
+	if c.Enabled {
+		return "Enabled"
+	}
+
+	return "Disabled"
+}

--- a/internal/web/templates/users_v2.templ
+++ b/internal/web/templates/users_v2.templ
@@ -40,7 +40,7 @@ templ UsersListV2(users []ldap.User, showDisabled bool, ouFilter string, lastLog
 					<p class="list-page__count">{ fmt.Sprintf("%d", len(users)) } users</p>
 				</div>
 				<div class="list-page__head-controls">
-					@listGraphToggle("/users", currentView, usersFilterQS(showDisabled, ouFilter, lastLogon, memberOfDN))
+					@listGraphToggle("/users", currentView, UsersFilterQS(showDisabled, ouFilter, lastLogon, memberOfDN))
 				</div>
 			</header>
 
@@ -749,11 +749,11 @@ func userOUHrefFactory(showDisabled bool, lastLogon, memberOfDN string) ouHref {
 	}
 }
 
-// usersFilterQS encodes the active /users filter combination as a bare
+// UsersFilterQS encodes the active /users filter combination as a bare
 // query string (no leading "?", no view selector). Used by the
 // listGraphToggle to preserve filters when switching between
 // list / graph segments.
-func usersFilterQS(showDisabled bool, ouFilter, lastLogon, memberOfDN string) string {
+func UsersFilterQS(showDisabled bool, ouFilter, lastLogon, memberOfDN string) string {
 	v := url.Values{}
 	if showDisabled {
 		v.Set("show-disabled", "1")

--- a/internal/web/templates/users_v2.templ
+++ b/internal/web/templates/users_v2.templ
@@ -35,9 +35,13 @@ templ UsersListV2(users []ldap.User, showDisabled bool, ouFilter string, lastLog
 
 		<main id="main-content" class="list-page" data-bulk-scope="users">
 			<header class="list-page__head">
-				<h1 class="list-page__title">Users</h1>
-				<p class="list-page__count">{ fmt.Sprintf("%d", len(users)) } users</p>
-				@listGraphToggle("/users", currentView, usersFilterQS(showDisabled, ouFilter, lastLogon, memberOfDN))
+				<div class="list-page__head-titles">
+					<h1 class="list-page__title">Users</h1>
+					<p class="list-page__count">{ fmt.Sprintf("%d", len(users)) } users</p>
+				</div>
+				<div class="list-page__head-controls">
+					@listGraphToggle("/users", currentView, usersFilterQS(showDisabled, ouFilter, lastLogon, memberOfDN))
+				</div>
 			</header>
 
 			@listFlashes(flashes)

--- a/internal/web/users_v2_handler.go
+++ b/internal/web/users_v2_handler.go
@@ -102,16 +102,27 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 	users = filterUsersByMemberOf(users, memberOf, a.ldapCache)
 	sortUsersByCN(users)
 
-	currentView := c.Query("view")
+	currentView := pickView(c)
 	if a.ldapCache == nil {
-		currentView = ""
+		// Cache-less mode can't render graph or table — they need cache lookups
+		// for membership and the list filters. Force list view, but DON'T
+		// rewrite the cookie; if the user re-enables the service account,
+		// their previous preference returns.
+		currentView = "list"
 	}
 
-	if currentView == "graph" && a.ldapCache != nil {
+	if currentView == "graph" {
 		data := a.ldapCache.BuildListGraph(users, nil)
 		vm := templates.GraphPageVM{Data: data, BackHref: "/users", FocusLabel: "Users"}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
+	}
+
+	if currentView == "table" {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
+
+		return templates.UsersListTableV2(users, currentView, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 
 	memberOfCN := lookupGroupCN(memberOf, a.ldapCache)

--- a/internal/web/users_v2_handler.go
+++ b/internal/web/users_v2_handler.go
@@ -111,9 +111,11 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 		currentView = "list"
 	}
 
+	filterQS := templates.UsersFilterQS(showDisabled, ouFilter, lastLogon, memberOf)
+
 	if currentView == "graph" {
 		data := a.ldapCache.BuildListGraph(users, nil)
-		vm := templates.GraphPageVM{Data: data, BackHref: "/users", FocusLabel: "Users"}
+		vm := templates.GraphPageVM{Data: data, BackHref: "/users", FocusLabel: "Users", FilterQS: filterQS}
 
 		return a.templateCache.RenderWithCache(c, templates.GraphPageV2(vm))
 	}
@@ -121,7 +123,7 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 	if currentView == "table" {
 		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-		return templates.UsersListTableV2(users, currentView, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+		return templates.UsersListTableV2(users, currentView, filterQS, a.takeFlash(c), a.paletteContextFor(viewerDN)).
 			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 


### PR DESCRIPTION
## Summary

Live-review polish on top of the Phase 3 graph view, plus a long-requested Table list mode and a real bug fix on AD-backed deployments. All driven by an interactive review session against the `ldap.netresearch.nr` AD.

## What ships

### Bug fixes

- **Computer accounts no longer leak into the users list.** simple-ldap-go's `FindUsers` filter `(|(objectClass=user)(objectClass=inetOrgPerson)(objectClass=person))` matches AD computer accounts (which inherit `objectClass=user`), so `/users` was showing machine accounts alongside real users. Filter at the cache layer via DN intersection with the Computers cache.
- **Table view rendered as plain text** because the new branch didn't set `Content-Type: text/html`.
- **View persistence "sometimes worked"** — the template-cache key didn't include the `graph-view` cookie, so the first cached `/users` render stuck regardless of the per-user preference.

### Phase 3 polish (from live-review feedback)

- **Collapse**: clicking an expanded node's `−` badge now removes the added sub-tree transitively and restores `+`. Keyboard parity via `−` / `_`.
- **Page scrolling**: graph page switched to `baseV2PageScroll` so the relationships table below the canvas is reachable.
- **Cursor-anchored zoom**: fixed math by converting mouse to SVG user-space via `getScreenCTM().inverse()` before scaling — previous mix of screen pixels and viewBox units drifted noticeably.
- **Hover/focus highlights incident edges**: hovering or focusing a node darkens every edge that touches it (JS-toggled `.graph-edge--hover-related` class).
- **Dark-mode disc colours**: per-type fills shifted one tone away from `--bg-subtle` (canvas background), which previously matched user-disc fill exactly and made discs invisible.

### Weighting (the "the graph feels static" feedback)

- **Degree-scaled disc size**: each node's `Degree` is computed once from the rendered edge set; both SSR and JS-rendered nodes scale disc radius from base 22 (+1.5 per edge, capped at 32) so high-connectivity hubs read as visually weightier than leaves.
- **Parent-anchored angles**: rings 2+ now place each child near its ring-(N-1) parent. Children of the same parent occupy a contiguous arc whose width is proportional to count. Result: clusters of related nodes form spokes radiating outward from the focus, replacing alphabetical shuffle.

### Persistent List | Table | Graph view selection

- **New "Table" view** for users/groups/computers — full-width scannable table without OU filter rail or detail drawer. Each row links straight to the entity's detail page. Optimised for browsing many rows at once.
- **Cookie-backed view persistence** (`graph-view`, 30 days, SameSite=Strict, HttpOnly): pickView() reads `?view=` when present (refreshing the cookie) and falls back to the cookie value otherwise. Picking Table on `/users` sticks across `/groups` and `/computers`.
- **Three-segment toggle** (List | Table | Graph) with always-explicit `?view=` so each click re-asserts the user's choice.

### UI consistency

- **Subheader homogenisation**: all four list-bearing templates (users/groups/computers/graph) now use the same `.list-page__head` structure with `.list-page__head-titles` (left) + `.list-page__head-controls` auto-margined right. The toggle stays in a fixed screen position regardless of view.
- **Page width unification**: `list-table-page` and `graph-page` now share `.list-page`'s `max-width: 72rem` + auto-centering so all three subheaders align gutter-to-gutter.

### Dark/console-mode polish

- Depth slider tinted via `accent-color: var(--accent)` instead of the OS-default white.
- Graph + list tables: explicit `color: var(--fg)` + `font-family: inherit` so headers and body text honour the dark/console theme (which swaps body to monospace).
- "Relationships" h2 in the graph view: explicit `color: var(--fg)` so it picks up the theme.
- SVG `.graph-node__label` text inherits the body font so node labels switch to monospace in dark mode alongside the page text.

### Active-tab hover

- Active segmented option no longer flashes to `--bg-subtle` (which equals `--bg` in dark mode and rendered as black-on-black). `:not(.--active)` guard on the hover rule.

## Commits (atomic, signed + DCO)

```
b1cc58e fix(ui): unify subheader layout, page width + dark/console-mode polish
9e9faaf feat(web): Table view + persistent List/Table/Graph selection
7d64bd4 fix(cache): exclude AD computer accounts from FindUsers
23a2611 feat(graph): weighted layout — degree-scaled disc + parent-anchored angles
8057da2 fix(graph): post-review polish (collapse, scroll, zoom anchor, hover, dark mode)
```

## Test plan

- [x] `go test ./internal/web/ ./internal/ldap_cache/...` — no regressions
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` + `go build -tags e2e ./internal/e2e/...` — clean
- [x] `templ generate` — clean
- [x] Manual smoke against real AD (`ldap.netresearch.nr`, 181 users / 108 groups / 73 computers) covering: List/Table/Graph toggle, view persistence across pages, Computer exclusion from /users, dark-mode visibility of all elements, expand/collapse on graph nodes, cursor-anchored zoom.
- [ ] CI verification on push.