### PR TITLE
feat(web): Table view — client-side filter + sortable column headers

### DIFF
--- a/internal/web/computers_v2_handler.go
+++ b/internal/web/computers_v2_handler.go
@@ -83,11 +83,15 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 		computers = filterComputersByOU(all, ouFilter)
 	}
 
-	sortComputersByCN(computers)
-
 	currentView := pickView(c)
 	if a.ldapCache == nil {
 		currentView = "list"
+	}
+
+	// Skip the CN pre-sort when the table view will sort by its own
+	// (sortKey, sortDir) below — avoids an unnecessary O(n log n) pass.
+	if currentView != "table" {
+		sortComputersByCN(computers)
 	}
 
 	filterQS := templates.ComputersFilterQS(ouFilter)

--- a/internal/web/computers_v2_handler.go
+++ b/internal/web/computers_v2_handler.go
@@ -100,9 +100,13 @@ func (a *App) handleComputersV2(c *fiber.Ctx) error {
 	}
 
 	if currentView == "table" {
+		sortKey := c.Query("sort", "cn")
+		sortDir := normaliseSortDir(c.Query("dir", "asc"))
+		sortComputersTable(computers, sortKey, sortDir)
+
 		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-		return templates.ComputersListTableV2(computers, currentView, filterQS, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+		return templates.ComputersListTableV2(computers, currentView, filterQS, sortKey, sortDir, a.takeFlash(c), a.paletteContextFor(viewerDN)).
 			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 

--- a/internal/web/graph_v2_handler_test.go
+++ b/internal/web/graph_v2_handler_test.go
@@ -345,7 +345,8 @@ func TestHandleUsersV2_TableMode(t *testing.T) {
 
 	for _, marker := range []string{
 		`class="list-table"`,
-		`<th scope="col">CN</th>`,
+		`list-table__sort-link`, // sortable column-header anchor
+		`data-search-input`,     // client-side filter input
 		"bob",
 		`graph-segmented`,
 	} {

--- a/internal/web/groups_v2_handler.go
+++ b/internal/web/groups_v2_handler.go
@@ -294,11 +294,16 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 	ous := distinctImmediateOUsFromGroups(all)
 	groups := filterGroupsByOU(all, ouFilter)
 	groups = filterGroupsByMember(groups, memberDN)
-	sortGroupsByCN(groups)
 
 	currentView := pickView(c)
 	if a.ldapCache == nil {
 		currentView = "list"
+	}
+
+	// Skip the CN pre-sort when the table view will sort by its own
+	// (sortKey, sortDir) below — avoids an unnecessary O(n log n) pass.
+	if currentView != "table" {
+		sortGroupsByCN(groups)
 	}
 
 	filterQS := templates.GroupsFilterQS(ouFilter, memberDN)

--- a/internal/web/groups_v2_handler.go
+++ b/internal/web/groups_v2_handler.go
@@ -327,9 +327,13 @@ func (a *App) handleGroupsV2(c *fiber.Ctx) error {
 	}
 
 	if currentView == "table" {
+		sortKey := c.Query("sort", "cn")
+		sortDir := normaliseSortDir(c.Query("dir", "asc"))
+		sortGroupsTable(groups, sortKey, sortDir)
+
 		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-		return templates.GroupsListTableV2(groups, currentView, filterQS, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+		return templates.GroupsListTableV2(groups, currentView, filterQS, sortKey, sortDir, a.takeFlash(c), a.paletteContextFor(viewerDN)).
 			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 

--- a/internal/web/static/app.css
+++ b/internal/web/static/app.css
@@ -2786,3 +2786,38 @@ button.kv-edit__save {
 .list-table__link:hover { text-decoration: underline; }
 .list-table__num { font-variant-numeric: tabular-nums; text-align: right; }
 .list-table__dn { color: var(--fg-muted); font-family: var(--font-mono, monospace); font-size: 0.85rem; word-break: break-all; }
+
+/* Search input directly above the table — same data-search-filter
+   wiring as the list view, so v2-search-filter.js handles row-hide
+   without further JS. */
+.list-table-filter { display: flex; flex-direction: column; gap: 0.75rem; }
+.list-table-filter__input {
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  font: inherit;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.list-table-filter__input:focus-visible {
+  outline: 2px solid var(--border-strong);
+  outline-offset: 2px;
+}
+
+/* Sortable column headers — anchor links so click-navigation works
+   without JS, indicator arrows show the active sort + direction. */
+.list-table__sort-th { padding: 0; }
+.list-table__sort-link {
+  display: block;
+  padding: 0.5rem 0.8rem;
+  color: var(--fg);
+  text-decoration: none;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  font-weight: 600;
+}
+.list-table__sort-link:hover { background: var(--border); }
+.list-table__sort-link:focus-visible { outline: 2px solid var(--border-strong); outline-offset: -2px; }
+.list-table__sort-indicator { color: var(--fg-muted); font-weight: 400; }

--- a/internal/web/table_sort.go
+++ b/internal/web/table_sort.go
@@ -1,0 +1,156 @@
+// internal/web/table_sort.go — sort helpers for the Table view
+// (List | Table | Graph). Sort key + direction are server-side
+// query params (?sort=col&dir=asc|desc), so the URL captures the
+// sort state and back/forward navigation works without JS.
+package web
+
+import (
+	"sort"
+	"strings"
+
+	ldap "github.com/netresearch/simple-ldap-go"
+)
+
+// normaliseSortDir clamps an unknown direction to "asc". Used so an
+// arbitrary ?dir=foo doesn't turn into a bug downstream.
+func normaliseSortDir(d string) string {
+	if d == "desc" {
+		return "desc"
+	}
+
+	return "asc"
+}
+
+// sortUsersTable sorts users in place by the requested column. Unknown
+// sort keys fall back to CN — the default column the table is
+// initially shown in.
+func sortUsersTable(users []ldap.User, key, dir string) {
+	dir = normaliseSortDir(dir)
+
+	less := func(i, j int) bool {
+		var a, b string
+
+		switch key {
+		case "sam":
+			a, b = users[i].SAMAccountName, users[j].SAMAccountName
+		case "mail":
+			if users[i].Mail != nil {
+				a = *users[i].Mail
+			}
+			if users[j].Mail != nil {
+				b = *users[j].Mail
+			}
+		case "status":
+			a, b = userStatusForSort(users[i]), userStatusForSort(users[j])
+		default: // "cn"
+			a, b = users[i].CN(), users[j].CN()
+		}
+
+		if a == b {
+			// Stable secondary key on DN so otherwise-equal rows have a
+			// deterministic order across renders.
+			return users[i].DN() < users[j].DN()
+		}
+
+		if dir == "desc" {
+			return strings.ToLower(a) > strings.ToLower(b)
+		}
+
+		return strings.ToLower(a) < strings.ToLower(b)
+	}
+
+	sort.SliceStable(users, less)
+}
+
+// sortGroupsTable sorts groups by the requested column.
+func sortGroupsTable(groups []ldap.Group, key, dir string) {
+	dir = normaliseSortDir(dir)
+
+	less := func(i, j int) bool {
+		switch key {
+		case "members":
+			a, b := len(groups[i].Members), len(groups[j].Members)
+			if a == b {
+				return groups[i].DN() < groups[j].DN()
+			}
+
+			if dir == "desc" {
+				return a > b
+			}
+
+			return a < b
+		case "dn":
+			a, b := groups[i].DN(), groups[j].DN()
+			if dir == "desc" {
+				return strings.ToLower(a) > strings.ToLower(b)
+			}
+
+			return strings.ToLower(a) < strings.ToLower(b)
+		default: // "cn"
+			a, b := groups[i].CN(), groups[j].CN()
+			if a == b {
+				return groups[i].DN() < groups[j].DN()
+			}
+
+			if dir == "desc" {
+				return strings.ToLower(a) > strings.ToLower(b)
+			}
+
+			return strings.ToLower(a) < strings.ToLower(b)
+		}
+	}
+
+	sort.SliceStable(groups, less)
+}
+
+// sortComputersTable sorts computers by the requested column.
+func sortComputersTable(computers []ldap.Computer, key, dir string) {
+	dir = normaliseSortDir(dir)
+
+	less := func(i, j int) bool {
+		var a, b string
+
+		switch key {
+		case "sam":
+			a, b = computers[i].SAMAccountName, computers[j].SAMAccountName
+		case "status":
+			a, b = computerStatusForSort(computers[i]), computerStatusForSort(computers[j])
+		case "dn":
+			a, b = computers[i].DN(), computers[j].DN()
+		default: // "cn"
+			a, b = computers[i].CN(), computers[j].CN()
+		}
+
+		if a == b {
+			return computers[i].DN() < computers[j].DN()
+		}
+
+		if dir == "desc" {
+			return strings.ToLower(a) > strings.ToLower(b)
+		}
+
+		return strings.ToLower(a) < strings.ToLower(b)
+	}
+
+	sort.SliceStable(computers, less)
+}
+
+// userStatusForSort maps Enabled→"a" / Disabled→"b" so an asc sort
+// puts enabled rows on top — the more useful default than alphabetical
+// "Disabled" / "Enabled".
+func userStatusForSort(u ldap.User) string {
+	if u.Enabled {
+		return "a"
+	}
+
+	return "b"
+}
+
+// computerStatusForSort mirrors userStatusForSort.
+func computerStatusForSort(c ldap.Computer) string {
+	if c.Enabled {
+		return "a"
+	}
+
+	return "b"
+}

--- a/internal/web/table_sort.go
+++ b/internal/web/table_sort.go
@@ -21,6 +21,25 @@ func normaliseSortDir(d string) string {
 	return "asc"
 }
 
+// stringLess applies the requested direction to a case-insensitive
+// comparison. The DN secondary key needs to be applied when the two
+// inputs are equal under the same case-insensitive rule the primary
+// comparison uses — earlier `a == b` (case-sensitive) skipped the
+// tie-break for inputs that differed only in case, leaving ordering
+// at the mercy of input-slice order.
+func stringLess(a, b, tieA, tieB, dir string) bool {
+	if strings.EqualFold(a, b) {
+		return tieA < tieB
+	}
+
+	la, lb := strings.ToLower(a), strings.ToLower(b)
+	if dir == "desc" {
+		return la > lb
+	}
+
+	return la < lb
+}
+
 // sortUsersTable sorts users in place by the requested column. Unknown
 // sort keys fall back to CN — the default column the table is
 // initially shown in.
@@ -46,17 +65,7 @@ func sortUsersTable(users []ldap.User, key, dir string) {
 			a, b = users[i].CN(), users[j].CN()
 		}
 
-		if a == b {
-			// Stable secondary key on DN so otherwise-equal rows have a
-			// deterministic order across renders.
-			return users[i].DN() < users[j].DN()
-		}
-
-		if dir == "desc" {
-			return strings.ToLower(a) > strings.ToLower(b)
-		}
-
-		return strings.ToLower(a) < strings.ToLower(b)
+		return stringLess(a, b, users[i].DN(), users[j].DN(), dir)
 	}
 
 	sort.SliceStable(users, less)
@@ -80,23 +89,9 @@ func sortGroupsTable(groups []ldap.Group, key, dir string) {
 
 			return a < b
 		case "dn":
-			a, b := groups[i].DN(), groups[j].DN()
-			if dir == "desc" {
-				return strings.ToLower(a) > strings.ToLower(b)
-			}
-
-			return strings.ToLower(a) < strings.ToLower(b)
+			return stringLess(groups[i].DN(), groups[j].DN(), groups[i].DN(), groups[j].DN(), dir)
 		default: // "cn"
-			a, b := groups[i].CN(), groups[j].CN()
-			if a == b {
-				return groups[i].DN() < groups[j].DN()
-			}
-
-			if dir == "desc" {
-				return strings.ToLower(a) > strings.ToLower(b)
-			}
-
-			return strings.ToLower(a) < strings.ToLower(b)
+			return stringLess(groups[i].CN(), groups[j].CN(), groups[i].DN(), groups[j].DN(), dir)
 		}
 	}
 
@@ -121,15 +116,7 @@ func sortComputersTable(computers []ldap.Computer, key, dir string) {
 			a, b = computers[i].CN(), computers[j].CN()
 		}
 
-		if a == b {
-			return computers[i].DN() < computers[j].DN()
-		}
-
-		if dir == "desc" {
-			return strings.ToLower(a) > strings.ToLower(b)
-		}
-
-		return strings.ToLower(a) < strings.ToLower(b)
+		return stringLess(a, b, computers[i].DN(), computers[j].DN(), dir)
 	}
 
 	sort.SliceStable(computers, less)

--- a/internal/web/table_sort_test.go
+++ b/internal/web/table_sort_test.go
@@ -1,0 +1,82 @@
+// internal/web/table_sort_test.go — unit coverage for the Table-view
+// server-side sort helpers. Stays in the web package so the test sees
+// the unexported sortUsersTable / sortGroupsTable / sortComputersTable
+// directly.
+package web
+
+import (
+	"testing"
+
+	ldap "github.com/netresearch/simple-ldap-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netresearch/ldap-manager/internal/ldap_cache/cachetest"
+)
+
+func TestNormaliseSortDir(t *testing.T) {
+	require.Equal(t, "asc", normaliseSortDir(""))
+	require.Equal(t, "asc", normaliseSortDir("foo"))
+	require.Equal(t, "asc", normaliseSortDir("ASC")) // case-sensitive: only literal "desc" wins
+	require.Equal(t, "desc", normaliseSortDir("desc"))
+}
+
+func TestSortUsersTable_ByCNAscDesc(t *testing.T) {
+	users := []ldap.User{
+		cachetest.NewUserWithDN("cn=charlie,dc=ex,dc=com", "charlie", "csam", true, nil),
+		cachetest.NewUserWithDN("cn=alice,dc=ex,dc=com", "alice", "asam", true, nil),
+		cachetest.NewUserWithDN("cn=bob,dc=ex,dc=com", "bob", "bsam", false, nil),
+	}
+
+	sortUsersTable(users, "cn", "asc")
+	require.Equal(t, "alice", users[0].CN())
+	require.Equal(t, "bob", users[1].CN())
+	require.Equal(t, "charlie", users[2].CN())
+
+	sortUsersTable(users, "cn", "desc")
+	require.Equal(t, "charlie", users[0].CN())
+	require.Equal(t, "bob", users[1].CN())
+	require.Equal(t, "alice", users[2].CN())
+}
+
+func TestSortUsersTable_ByStatusEnabledFirst(t *testing.T) {
+	users := []ldap.User{
+		cachetest.NewUserWithDN("cn=disabled,dc=ex,dc=com", "disabled", "d", false, nil),
+		cachetest.NewUserWithDN("cn=enabled,dc=ex,dc=com", "enabled", "e", true, nil),
+	}
+	sortUsersTable(users, "status", "asc")
+	// "Enabled" (key "a") < "Disabled" (key "b") so enabled rows come
+	// first under asc — the documented contract for the status sort.
+	require.True(t, users[0].Enabled, "first row should be enabled under asc status sort")
+	require.False(t, users[1].Enabled)
+}
+
+func TestSortUsersTable_UnknownKeyFallsBackToCN(t *testing.T) {
+	users := []ldap.User{
+		cachetest.NewUserWithDN("cn=zed,dc=ex,dc=com", "zed", "z", true, nil),
+		cachetest.NewUserWithDN("cn=ann,dc=ex,dc=com", "ann", "a", true, nil),
+	}
+	sortUsersTable(users, "lol-not-a-column", "asc")
+	require.Equal(t, "ann", users[0].CN(), "unknown sort key should fall back to CN")
+}
+
+func TestSortGroupsTable_ByMembersDesc(t *testing.T) {
+	groups := []ldap.Group{
+		cachetest.NewGroupWithDN("cn=small,dc=ex,dc=com", "small", []string{"a"}),
+		cachetest.NewGroupWithDN("cn=big,dc=ex,dc=com", "big", []string{"a", "b", "c"}),
+		cachetest.NewGroupWithDN("cn=mid,dc=ex,dc=com", "mid", []string{"a", "b"}),
+	}
+	sortGroupsTable(groups, "members", "desc")
+	require.Equal(t, "big", groups[0].CN())
+	require.Equal(t, "mid", groups[1].CN())
+	require.Equal(t, "small", groups[2].CN())
+}
+
+func TestSortComputersTable_BySAM(t *testing.T) {
+	computers := []ldap.Computer{
+		cachetest.NewComputerWithDN("cn=ws03,dc=ex,dc=com", "ws03", "ws03$", true, nil),
+		cachetest.NewComputerWithDN("cn=ws01,dc=ex,dc=com", "ws01", "ws01$", true, nil),
+	}
+	sortComputersTable(computers, "sam", "asc")
+	require.Equal(t, "ws01$", computers[0].SAMAccountName)
+	require.Equal(t, "ws03$", computers[1].SAMAccountName)
+}

--- a/internal/web/templates/list_table_v2.templ
+++ b/internal/web/templates/list_table_v2.templ
@@ -10,126 +10,269 @@ package templates
 
 import (
 	"fmt"
+	"net/url"
 
 	ldap "github.com/netresearch/simple-ldap-go"
 )
 
 // UsersListTableV2 renders the full-width users table.
-templ UsersListTableV2(users []ldap.User, currentView, filterQS string, flashes []Flash, palettePinned []PinnedEntry) {
+templ UsersListTableV2(users []ldap.User, currentView, filterQS, sortKey, sortDir string, flashes []Flash, palettePinned []PinnedEntry) {
 	@baseV2PageScroll("Users — Table") {
 		@topnavV2("/users")
 		<main id="main-content" class="list-table-page">
 			<header class="list-page__head">
 				<div class="list-page__head-titles">
 					<h1 class="list-page__title">Users</h1>
-					<p class="list-page__count">{ fmt.Sprintf("%d users", len(users)) }</p>
+					<p class="list-page__count" data-search-count>{ fmt.Sprintf("%d users", len(users)) }</p>
 				</div>
 				<div class="list-page__head-controls">
 					@listGraphToggle("/users", currentView, filterQS)
 				</div>
 			</header>
 			@listFlashes(flashes)
-			<table class="list-table">
-				<thead>
-					<tr>
-						<th scope="col">CN</th>
-						<th scope="col">SAM account</th>
-						<th scope="col">Mail</th>
-						<th scope="col">Status</th>
-					</tr>
-				</thead>
-				<tbody>
-					for _, u := range users {
+			<div class="list-table-filter" data-search-filter data-search-scope>
+				<input
+					type="search"
+					class="list-table-filter__input"
+					placeholder="Filter users…"
+					aria-label="Filter users"
+					data-search-input
+					autocomplete="off"
+					autocorrect="off"
+					autocapitalize="off"
+					spellcheck="false"
+					data-1p-ignore
+					data-lpignore="true"
+					data-form-type="other"
+				/>
+				<table class="list-table" data-search-list>
+					<thead>
 						<tr>
-							<td><a class="list-table__link" href={ userDetailHref(u) }>{ u.CN() }</a></td>
-							<td>{ u.SAMAccountName }</td>
-							<td>{ derefString(u.Mail) }</td>
-							<td>{ userStatusLabel(u) }</td>
+							@tableSortHeader("/users", "cn", "CN", sortKey, sortDir, filterQS)
+							@tableSortHeader("/users", "sam", "SAM account", sortKey, sortDir, filterQS)
+							@tableSortHeader("/users", "mail", "Mail", sortKey, sortDir, filterQS)
+							@tableSortHeader("/users", "status", "Status", sortKey, sortDir, filterQS)
 						</tr>
-					}
-				</tbody>
-			</table>
+					</thead>
+					<tbody>
+						for _, u := range users {
+							<tr data-search-item data-search-text={ usersTableSearchText(u) }>
+								<td><a class="list-table__link" href={ userDetailHref(u) }>{ u.CN() }</a></td>
+								<td>{ u.SAMAccountName }</td>
+								<td>{ derefString(u.Mail) }</td>
+								<td>{ userStatusLabel(u) }</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
 			@paletteV2WithPinned(palettePinned)
 		</main>
 	}
 }
 
 // GroupsListTableV2 renders the full-width groups table.
-templ GroupsListTableV2(groups []ldap.Group, currentView, filterQS string, flashes []Flash, palettePinned []PinnedEntry) {
+templ GroupsListTableV2(groups []ldap.Group, currentView, filterQS, sortKey, sortDir string, flashes []Flash, palettePinned []PinnedEntry) {
 	@baseV2PageScroll("Groups — Table") {
 		@topnavV2("/groups")
 		<main id="main-content" class="list-table-page">
 			<header class="list-page__head">
 				<div class="list-page__head-titles">
 					<h1 class="list-page__title">Groups</h1>
-					<p class="list-page__count">{ fmt.Sprintf("%d groups", len(groups)) }</p>
+					<p class="list-page__count" data-search-count>{ fmt.Sprintf("%d groups", len(groups)) }</p>
 				</div>
 				<div class="list-page__head-controls">
 					@listGraphToggle("/groups", currentView, filterQS)
 				</div>
 			</header>
 			@listFlashes(flashes)
-			<table class="list-table">
-				<thead>
-					<tr>
-						<th scope="col">CN</th>
-						<th scope="col">Members</th>
-						<th scope="col">DN</th>
-					</tr>
-				</thead>
-				<tbody>
-					for _, g := range groups {
+			<div class="list-table-filter" data-search-filter data-search-scope>
+				<input
+					type="search"
+					class="list-table-filter__input"
+					placeholder="Filter groups…"
+					aria-label="Filter groups"
+					data-search-input
+					autocomplete="off"
+					autocorrect="off"
+					autocapitalize="off"
+					spellcheck="false"
+					data-1p-ignore
+					data-lpignore="true"
+					data-form-type="other"
+				/>
+				<table class="list-table" data-search-list>
+					<thead>
 						<tr>
-							<td><a class="list-table__link" href={ groupDetailHref(g) }>{ g.CN() }</a></td>
-							<td class="list-table__num">{ fmt.Sprintf("%d", len(g.Members)) }</td>
-							<td class="list-table__dn">{ g.DN() }</td>
+							@tableSortHeader("/groups", "cn", "CN", sortKey, sortDir, filterQS)
+							@tableSortHeader("/groups", "members", "Members", sortKey, sortDir, filterQS)
+							@tableSortHeader("/groups", "dn", "DN", sortKey, sortDir, filterQS)
 						</tr>
-					}
-				</tbody>
-			</table>
+					</thead>
+					<tbody>
+						for _, g := range groups {
+							<tr data-search-item data-search-text={ groupsTableSearchText(g) }>
+								<td><a class="list-table__link" href={ groupDetailHref(g) }>{ g.CN() }</a></td>
+								<td class="list-table__num">{ fmt.Sprintf("%d", len(g.Members)) }</td>
+								<td class="list-table__dn">{ g.DN() }</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
 			@paletteV2WithPinned(palettePinned)
 		</main>
 	}
 }
 
 // ComputersListTableV2 renders the full-width computers table.
-templ ComputersListTableV2(computers []ldap.Computer, currentView, filterQS string, flashes []Flash, palettePinned []PinnedEntry) {
+templ ComputersListTableV2(computers []ldap.Computer, currentView, filterQS, sortKey, sortDir string, flashes []Flash, palettePinned []PinnedEntry) {
 	@baseV2PageScroll("Computers — Table") {
 		@topnavV2("/computers")
 		<main id="main-content" class="list-table-page">
 			<header class="list-page__head">
 				<div class="list-page__head-titles">
 					<h1 class="list-page__title">Computers</h1>
-					<p class="list-page__count">{ fmt.Sprintf("%d computers", len(computers)) }</p>
+					<p class="list-page__count" data-search-count>{ fmt.Sprintf("%d computers", len(computers)) }</p>
 				</div>
 				<div class="list-page__head-controls">
 					@listGraphToggle("/computers", currentView, filterQS)
 				</div>
 			</header>
 			@listFlashes(flashes)
-			<table class="list-table">
-				<thead>
-					<tr>
-						<th scope="col">CN</th>
-						<th scope="col">SAM account</th>
-						<th scope="col">Status</th>
-						<th scope="col">DN</th>
-					</tr>
-				</thead>
-				<tbody>
-					for _, c := range computers {
+			<div class="list-table-filter" data-search-filter data-search-scope>
+				<input
+					type="search"
+					class="list-table-filter__input"
+					placeholder="Filter computers…"
+					aria-label="Filter computers"
+					data-search-input
+					autocomplete="off"
+					autocorrect="off"
+					autocapitalize="off"
+					spellcheck="false"
+					data-1p-ignore
+					data-lpignore="true"
+					data-form-type="other"
+				/>
+				<table class="list-table" data-search-list>
+					<thead>
 						<tr>
-							<td><a class="list-table__link" href={ computerDetailHref(c) }>{ c.CN() }</a></td>
-							<td>{ c.SAMAccountName }</td>
-							<td>{ computerStatusLabel(c) }</td>
-							<td class="list-table__dn">{ c.DN() }</td>
+							@tableSortHeader("/computers", "cn", "CN", sortKey, sortDir, filterQS)
+							@tableSortHeader("/computers", "sam", "SAM account", sortKey, sortDir, filterQS)
+							@tableSortHeader("/computers", "status", "Status", sortKey, sortDir, filterQS)
+							@tableSortHeader("/computers", "dn", "DN", sortKey, sortDir, filterQS)
 						</tr>
-					}
-				</tbody>
-			</table>
+					</thead>
+					<tbody>
+						for _, c := range computers {
+							<tr data-search-item data-search-text={ computersTableSearchText(c) }>
+								<td><a class="list-table__link" href={ computerDetailHref(c) }>{ c.CN() }</a></td>
+								<td>{ c.SAMAccountName }</td>
+								<td>{ computerStatusLabel(c) }</td>
+								<td class="list-table__dn">{ c.DN() }</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
 			@paletteV2WithPinned(palettePinned)
 		</main>
 	}
+}
+
+// tableSortHeader renders a column header that toggles the sort
+// direction when clicked. The href encodes ?view=table&sort=...&dir=...
+// plus the preserved filterQS so click navigation lands on the same
+// filtered subset with a refreshed sort.
+templ tableSortHeader(base, key, label, currentSort, currentDir, filterQS string) {
+	<th scope="col" class="list-table__sort-th">
+		<a class="list-table__sort-link" href={ templ.URL(buildTableSortHref(base, key, currentSort, currentDir, filterQS)) }>
+			{ label }
+			<span class="list-table__sort-indicator" aria-hidden="true">{ sortIndicator(key, currentSort, currentDir) }</span>
+		</a>
+	</th>
+}
+
+// buildSortHref computes the link URL for a column header. Clicking
+// the active column toggles direction; clicking an inactive column
+// switches to that column with asc direction.
+func buildTableSortHref(base, key, currentSort, currentDir, filterQS string) string {
+	dir := "asc"
+	if key == currentSort && currentDir == "asc" {
+		dir = "desc"
+	}
+
+	v := url.Values{}
+	v.Set("view", "table")
+	v.Set("sort", key)
+	v.Set("dir", dir)
+
+	out := v.Encode()
+	if filterQS != "" {
+		out = out + "&" + filterQS
+	}
+
+	return base + "?" + out
+}
+
+// sortIndicator returns the up / down arrow for the active column,
+// "" otherwise. Plain ascii arrows so screen readers and pico read
+// them consistently across themes.
+func sortIndicator(colKey, currentSort, currentDir string) string {
+	if colKey != currentSort {
+		return ""
+	}
+
+	if currentDir == "desc" {
+		return " ↓"
+	}
+
+	return " ↑"
+}
+
+// usersTableSearchText concatenates every user field the client-side
+// filter should match against. CN + SAM are visible; mail and DN are
+// included even when empty so searching by partial mail still works
+// when the column is blank for some rows.
+func usersTableSearchText(u ldap.User) string {
+	parts := []string{u.CN(), u.SAMAccountName, u.DN()}
+	if u.Mail != nil {
+		parts = append(parts, *u.Mail)
+	}
+
+	return joinParts(parts)
+}
+
+// groupsTableSearchText: CN + DN (members are a count, not text).
+func groupsTableSearchText(g ldap.Group) string {
+	return joinParts([]string{g.CN(), g.DN()})
+}
+
+// computersTableSearchText: CN + SAM + DN.
+func computersTableSearchText(c ldap.Computer) string {
+	return joinParts([]string{c.CN(), c.SAMAccountName, c.DN()})
+}
+
+// joinParts concatenates non-empty strings with spaces — keeps the
+// haystack short while still allowing the JS filter's substring
+// search to find any field.
+func joinParts(parts []string) string {
+	out := ""
+
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+
+		if out != "" {
+			out += " "
+		}
+
+		out += p
+	}
+
+	return out
 }
 
 // userStatusLabel — "Enabled" / "Disabled" cell content.

--- a/internal/web/templates/list_table_v2.templ
+++ b/internal/web/templates/list_table_v2.templ
@@ -23,7 +23,7 @@ templ UsersListTableV2(users []ldap.User, currentView, filterQS, sortKey, sortDi
 			<header class="list-page__head">
 				<div class="list-page__head-titles">
 					<h1 class="list-page__title">Users</h1>
-					<p class="list-page__count" data-search-count>{ fmt.Sprintf("%d users", len(users)) }</p>
+					<p class="list-page__count">{ fmt.Sprintf("%d users", len(users)) }</p>
 				</div>
 				<div class="list-page__head-controls">
 					@listGraphToggle("/users", currentView, filterQS)
@@ -79,7 +79,7 @@ templ GroupsListTableV2(groups []ldap.Group, currentView, filterQS, sortKey, sor
 			<header class="list-page__head">
 				<div class="list-page__head-titles">
 					<h1 class="list-page__title">Groups</h1>
-					<p class="list-page__count" data-search-count>{ fmt.Sprintf("%d groups", len(groups)) }</p>
+					<p class="list-page__count">{ fmt.Sprintf("%d groups", len(groups)) }</p>
 				</div>
 				<div class="list-page__head-controls">
 					@listGraphToggle("/groups", currentView, filterQS)
@@ -133,7 +133,7 @@ templ ComputersListTableV2(computers []ldap.Computer, currentView, filterQS, sor
 			<header class="list-page__head">
 				<div class="list-page__head-titles">
 					<h1 class="list-page__title">Computers</h1>
-					<p class="list-page__count" data-search-count>{ fmt.Sprintf("%d computers", len(computers)) }</p>
+					<p class="list-page__count">{ fmt.Sprintf("%d computers", len(computers)) }</p>
 				</div>
 				<div class="list-page__head-controls">
 					@listGraphToggle("/computers", currentView, filterQS)
@@ -194,7 +194,7 @@ templ tableSortHeader(base, key, label, currentSort, currentDir, filterQS string
 	</th>
 }
 
-// buildSortHref computes the link URL for a column header. Clicking
+// buildTableSortHref computes the link URL for a column header. Clicking
 // the active column toggles direction; clicking an inactive column
 // switches to that column with asc direction.
 func buildTableSortHref(base, key, currentSort, currentDir, filterQS string) string {
@@ -217,8 +217,9 @@ func buildTableSortHref(base, key, currentSort, currentDir, filterQS string) str
 }
 
 // sortIndicator returns the up / down arrow for the active column,
-// "" otherwise. Plain ascii arrows so screen readers and pico read
-// them consistently across themes.
+// "" otherwise. Uses Unicode ↑ / ↓ glyphs (U+2191 / U+2193) which
+// render consistently across the Pico/system font stack and screen
+// readers.
 func sortIndicator(colKey, currentSort, currentDir string) string {
 	if colKey != currentSort {
 		return ""

--- a/internal/web/users_v2_handler.go
+++ b/internal/web/users_v2_handler.go
@@ -121,9 +121,13 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 	}
 
 	if currentView == "table" {
+		sortKey := c.Query("sort", "cn")
+		sortDir := normaliseSortDir(c.Query("dir", "asc"))
+		sortUsersTable(users, sortKey, sortDir)
+
 		c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
 
-		return templates.UsersListTableV2(users, currentView, filterQS, a.takeFlash(c), a.paletteContextFor(viewerDN)).
+		return templates.UsersListTableV2(users, currentView, filterQS, sortKey, sortDir, a.takeFlash(c), a.paletteContextFor(viewerDN)).
 			Render(c.UserContext(), c.Response().BodyWriter())
 	}
 

--- a/internal/web/users_v2_handler.go
+++ b/internal/web/users_v2_handler.go
@@ -100,7 +100,6 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 	users := filterUsersByOU(all, ouFilter)
 	users = filterUsersByLastLogon(users, lastLogon)
 	users = filterUsersByMemberOf(users, memberOf, a.ldapCache)
-	sortUsersByCN(users)
 
 	currentView := pickView(c)
 	if a.ldapCache == nil {
@@ -109,6 +108,13 @@ func (a *App) handleUsersV2(c *fiber.Ctx) error {
 		// rewrite the cookie; if the user re-enables the service account,
 		// their previous preference returns.
 		currentView = "list"
+	}
+
+	// Pre-sort by CN for the views that don't sort themselves.
+	// Table view applies its own sortUsersTable() below; redoing this
+	// sort would be an unnecessary O(n log n) pass.
+	if currentView != "table" {
+		sortUsersByCN(users)
 	}
 
 	filterQS := templates.UsersFilterQS(showDisabled, ouFilter, lastLogon, memberOf)


### PR DESCRIPTION
## Summary

Closes the deferred follow-up from the live-review polish session ([#588](https://github.com/netresearch/ldap-manager/pull/588) handoff): the Table view now has a search input above the table and clickable column headers that toggle a server-side sort.

## What ships

### Client-side filter
- Search input above each Table view (`<input data-search-input>` inside a `data-search-filter` / `data-search-scope` container).
- Hooks into the existing `v2-search-filter.js` (no new JS needed). Rows hide via the `hidden` attribute when the haystack doesn't match.
- `data-search-text` on each `<tr>` concatenates CN, SAM, mail (where present), and DN so the substring filter matches visible and adjacent attributes.
- The visible row count in the subheader updates live via the existing `data-search-count` mechanism.
- `Esc` clears the input.

### Server-side sortable headers
- Column headers are anchor links carrying `?sort=col&dir=asc|desc` plus the preserved filter QS — so back/forward navigation and bookmarking work, no JS required.
- Clicking the active column toggles the direction; clicking another column resets to `asc`. The active column shows `↑` / `↓`.
- Sort columns:
  - Users: cn / sam / mail / status
  - Groups: cn / members / dn
  - Computers: cn / sam / status / dn
- Status sort: enabled rows first under asc — the more useful default than alphabetical "Disabled" / "Enabled".

### Tests

- `TestNormaliseSortDir` + per-entity sort tests (ascending/descending, status semantics, unknown-key fallback to CN, members count desc).
- `TestHandleUsersV2_TableMode` marker assertion updated to match the new sort-link / search-input markup.

## Out of scope

- Sort persistence ACROSS views (sort is meaningful only in Table view; the cookie-persisted view selection from PR #588 is unaffected).
- Multi-column sort (single column for v1).

## Test plan

- [x] `go test ./internal/web/ -count=1` — pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — clean
- [x] `templ generate` — clean
- [ ] CI verification on push
- [ ] Visual smoke (after merge): /users → Table → click "Status" header → enabled rows top; "Filter users…" → type "ad" → only matching rows visible; click "Graph" → return to /users → still Table view (cookie still works)