### PR TITLE
chore(release): v1.4.1 — fix release pipeline + README badges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,18 @@
 name: Release
 
-# Single-build release pipeline for go-app.
+# Atomic-release pipeline for go-app consumers. Delegates the entire
+# release lifecycle (preflight -> binaries -> container -> atomic publish)
+# to the release-go-app.yml reusable orchestrator.
 #
-# Go binaries are cross-compiled ONCE by the `binaries` matrix, uploaded
-# to the GitHub Release as user-facing artifacts, and then re-downloaded
-# into `bin/` where the Dockerfile's `COPY bin/<name>-linux-*` stage
-# picks the correct one per TARGETARCH/TARGETVARIANT. No `go build`
-# runs inside Docker.
-#
-# Convention for frontend-embedding repos: ship `bun run build:assets`
-# in package.json; this workflow invokes it before `go build` so assets
-# exist when `go:embed` resolves them. No-op when package.json is
-# absent, so non-frontend repos use this identical workflow unchanged.
-#
-# This file is template-managed — per-repo differences live in the
-# Dockerfile and (optionally) the package.json build:assets script.
-# Naming is derived from github.event.repository.name so the workflow
-# is byte-identical across consumers.
+# The orchestrator publishes the GitHub Release ATOMICALLY at the end —
+# avoiding the failure mode where create-release published an immutable
+# release before the binaries job could attach assets (HTTP 422 "Cannot
+# upload assets to an immutable release"). v1.4.1-rc2 validated this
+# pattern end-to-end.
 
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
   workflow_dispatch:
     inputs:
       tag:
@@ -28,126 +20,37 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  create-release:
-    name: Create GitHub Release
-    uses: netresearch/.github/.github/workflows/create-release.yml@main
+  release:
+    uses: netresearch/.github/.github/workflows/release-go-app.yml@main
     permissions:
       contents: write
-    with:
-      tag: ${{ inputs.tag || github.ref_name }}
-
-  binaries:
-    name: Build ${{ matrix.target }}
-    needs: create-release
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { target: linux-386,     goos: linux,   goarch: "386" }
-          - { target: linux-amd64,   goos: linux,   goarch: amd64 }
-          - { target: linux-arm64,   goos: linux,   goarch: arm64 }
-          - { target: linux-armv6,   goos: linux,   goarch: arm,   goarm: "6" }
-          - { target: linux-armv7,   goos: linux,   goarch: arm,   goarm: "7" }
-          - { target: darwin-amd64,  goos: darwin,  goarch: amd64 }
-          - { target: darwin-arm64,  goos: darwin,  goarch: arm64 }
-          - { target: windows-amd64, goos: windows, goarch: amd64 }
-    uses: netresearch/.github/.github/workflows/build-go-attest.yml@main
-    permissions:
-      contents: write
+      packages: write
       id-token: write
       attestations: write
+      security-events: write
     with:
-      binary-name: ${{ github.event.repository.name }}-${{ matrix.target }}
-      # Resolve after checkout (see build-go-attest.yml). `auto` picks
-      # `.` when ./main.go exists, else `./cmd/<repo-name>` when that
-      # main.go exists, else fails. Keeps this template file byte-
-      # identical regardless of whether the consumer uses a root-main
-      # or cmd/ layout.
-      main-package: auto
-      goos: ${{ matrix.goos }}
-      goarch: ${{ matrix.goarch }}
-      goarm: ${{ matrix.goarm || '' }}
-      # Fleet ldflag convention: repos that want to surface release
-      # metadata declare `var version, build, buildTime string` in their
-      # main package. Each repo decides which to forward into its own
-      # version package (ofelia uses main.* directly; ldap-manager
-      # forwards into internal/version.*). Empty values are a silent
-      # no-op for repos that don't declare the corresponding var.
-      # main.buildTime is injected via auto-build-timestamp (below)
-      # so it stays populated on workflow_dispatch backfills where
-      # github.event.head_commit is absent.
-      ldflags: >-
-        -s -w
-        -X main.version=${{ needs.create-release.outputs.tag }}
-        -X main.build=${{ needs.create-release.outputs.sha }}
-      auto-build-timestamp: true
-      ref: ${{ needs.create-release.outputs.tag }}
-      release-tag: ${{ needs.create-release.outputs.tag }}
-      sbom: true
-      # setup-bun runs unconditionally. `hashFiles()` in the caller's `with:`
-      # is evaluated BEFORE the reusable workflow's checkout, so the caller
-      # workspace is empty and any guard would have always returned false.
-      # The bun install/run commands below are `-f package.json`-gated, so
-      # non-frontend repos (ofelia, raybeam) pay only the ~10s Bun install
-      # overhead per matrix entry — no actual bun work happens.
+      app-name: ${{ github.event.repository.name }}
+      tag: ${{ inputs.tag || github.ref_name }}
+      # ldap-manager embeds Bun-built frontend assets via go:embed.
       setup-bun: true
+      # Pre-build hook: bun assets + templ generate.
+      # *_templ.go files are gitignored (internal/web/templates/.gitignore)
+      # so a clean checkout has none of them -- go build would fail to
+      # resolve types declared inside .templ sources without this step.
       pre-build-command: |
         if [ -f package.json ]; then
           bun install --frozen-lockfile
           bun run build:assets
         fi
-        # Generate Templ-backed Go code. The *_templ.go files are
-        # gitignored (internal/web/templates/.gitignore) so a clean
-        # checkout has none of them — go build would fail to resolve
-        # types declared inside .templ sources. Mirrors ci.yml's
-        # `pre-build-cmd`.
         go install github.com/a-h/templ/cmd/templ@latest
         templ generate
-
-  container:
-    name: Build container image
-    needs: [create-release, binaries]
-    uses: netresearch/.github/.github/workflows/build-container.yml@main
-    permissions:
-      contents: read
-      packages: write
-      security-events: write
-      id-token: write
-      attestations: write
-    with:
-      image-name: ${{ github.event.repository.name }}
-      ref: ${{ needs.create-release.outputs.tag }}
-      # gcr.io/distroless/static-debian12:nonroot (Dockerfile runner
-      # stage) only publishes linux/{amd64,arm/v7,arm64,ppc64le,s390x}.
-      # linux/386 and linux/arm/v6 aren't available; asking for them
-      # fails buildx with "no match for platform in manifest". The
-      # binaries matrix above still produces linux-386 / linux-armv6
-      # Go binaries as user-facing release downloads — they just
-      # don't ship inside the container image.
-      platforms: "linux/amd64,linux/arm/v7,linux/arm64"
-      sign: true
-      attest: true
-      pre-build-command: |
-        set -euo pipefail
-        mkdir -p bin
-        for suffix in linux-amd64 linux-arm64 linux-armv7; do
-          gh release download "${{ needs.create-release.outputs.tag }}" \
-            --pattern "${{ github.event.repository.name }}-${suffix}" --dir bin
-          chmod +x "bin/${{ github.event.repository.name }}-${suffix}"
-        done
-
-  finalize:
-    name: Finalize release (checksums, cosign, notes)
-    needs: [create-release, binaries, container]
-    uses: netresearch/.github/.github/workflows/finalize-release.yml@main
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
-    with:
-      tag: ${{ needs.create-release.outputs.tag }}
-      image-ref: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+      # gcr.io/distroless/static-debian12:nonroot (Dockerfile runner stage)
+      # only publishes linux/{amd64,arm/v7,arm64,ppc64le,s390x}. linux/386
+      # and linux/arm/v6 aren't available; asking for them fails buildx
+      # with "no match for platform in manifest". The binaries matrix still
+      # produces linux-386 / linux-armv6 Go binaries as user-facing release
+      # downloads -- they just don't ship inside the container image.
+      container-platforms: "linux/amd64,linux/arm/v7,linux/arm64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Tailwind CSS, PostCSS, TypeScript, and all associated build tooling (concurrently, nodemon, tsc, postcss-\*). The Go binary now builds assets itself via `templ generate` and ships Pico CSS + a hand-written `app.css` directly.
+- Tailwind CSS, PostCSS, TypeScript, Bun, and all associated build tooling (`package.json`, `bun.lock`, `tsconfig.json`, `tailwind.config.js`, `postcss.config.mjs`, concurrently, nodemon, tsc, postcss-\*). The Go binary now builds assets itself via `templ generate` and ships Pico CSS + a hand-written `app.css` + vendored htmx directly.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [v1.4.1] - 2026-04-27
+
+### Fixed
+
+- **Release pipeline:** Switch to `release-go-app.yml` atomic-release orchestrator. Previous pipeline created an immutable GitHub Release before the binaries job could attach assets, causing v1.3.0 and v1.4.0 to ship without binaries or container images (HTTP 422 "Cannot upload assets to an immutable release"). The orchestrator publishes atomically at the end after binaries + container builds succeed.
+- **README:** Repair broken CI/Container badges — workflow files were renamed (`quality.yml` → `ci.yml`, `docker.yml` → `container.yml`) without updating the README.
+
+---
+
+## [v1.4.0] - 2026-04-25
+
 ### Added
 
+- **Phase 3 graph view (Slices 1–6):** Server-rendered relationship graph with JSON endpoint, interactive JS canvas, list-page Graph mode (toggle + persistent selection), drawer pivots, weighted layout (degree-scaled disc + parent-anchored angles), and axe-core a11y ratchet. Includes "View relationships" drawer pivot, dark-mode + zoom anchoring, scroll-anchor fixes.
+- **Table view:** New per-page Table mode for `/users`, `/groups`, `/computers` with persistent List/Table/Graph selection. Server-rendered sortable column headers + client-side filter widget.
+
+### Fixed
+
+- `FindUsers` cache excludes AD computer accounts.
+- Subheader layout, page width, dark-mode and console-mode polish across list/detail pages.
+
+---
+
+## [v1.3.0] - 2026-04-24
+
+### Added
+
+- **UI revamp Phase 1:** Command-first interface with ⌘K palette, pin/unpin, recents, detail drawer. New hybrid light/dark theme (Inter sans in light, monospace in dark). WCAG 2.2 AAA conformance on all new surfaces, verified in CI via axe-core.
 - **UI revamp Phase 2:** Inline-edit for user email + description in the drawer via htmx; last-logon filter chips on `/users` (last 24h / 7d / 30d / never); toggleable OU tree rail on `/users`, `/groups`, `/computers` populated from distinct immediate-OU values in the cache.
-- **UI revamp Phase 3:** Bulk add-to-group on `/users` — per-row checkboxes feed a floating bulk-bar that POSTs `target_dn[]` + `group_dn` to `/users/bulk?action=add-to-group`. CSP-safe (external `v2-bulk.js`, `createElement`/`textContent` only).
+- **UI revamp Phase 3:** Bulk add-to-group, bulk + single disable (AD-gated, adminCount-based Privileged), and bulk delete for groups + computers with session flash. Per-row checkboxes feed a floating bulk-bar that POSTs `target_dn[]` + `group_dn` to `/users/bulk?action=add-to-group`. CSP-safe (external `v2-bulk.js`, `createElement` / `textContent` only).
 - **Phase 3 graph view deferral note:** `docs/superpowers/specs/2026-04-20-ui-revamp-phase-3-graph-view-deferred.md` — captures the rough shape and dependencies for the deferred relationship graph view.
 
 ### Changed
 
-- **UI revamp** (Phase 1): Command-first interface with ⌘K palette, pin/unpin, recents, detail drawer. New hybrid light/dark theme (Inter sans in light, monospace in dark). WCAG 2.2 AAA conformance on all new surfaces, verified in CI via axe-core.
+- Pinned-store hardening: hashed buckets, nil-safe, configurable path.
+- Use `ldap.ParseDN` for OU extraction with deterministic entry sort.
 
 ### Removed
 
-- Tailwind CSS, PostCSS, TypeScript, and all associated build tooling (bun, concurrently, nodemon, tsc, postcss-*). The Go binary now builds assets itself via `templ generate` and ships Pico CSS + a hand-written `app.css` directly.
+- Tailwind CSS, PostCSS, TypeScript, and all associated build tooling (concurrently, nodemon, tsc, postcss-\*). The Go binary now builds assets itself via `templ generate` and ships Pico CSS + a hand-written `app.css` directly.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 Supports both Active Directory and OpenLDAP with per-user credential binding.
 
-[![CI](https://github.com/netresearch/ldap-manager/actions/workflows/quality.yml/badge.svg)](https://github.com/netresearch/ldap-manager/actions/workflows/quality.yml)
-[![Docker](https://github.com/netresearch/ldap-manager/actions/workflows/docker.yml/badge.svg)](https://github.com/netresearch/ldap-manager/actions/workflows/docker.yml)
+[![CI](https://github.com/netresearch/ldap-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/ldap-manager/actions/workflows/ci.yml)
+[![Container](https://github.com/netresearch/ldap-manager/actions/workflows/container.yml/badge.svg)](https://github.com/netresearch/ldap-manager/actions/workflows/container.yml)
 [![codecov](https://codecov.io/gh/netresearch/ldap-manager/graph/badge.svg)](https://codecov.io/gh/netresearch/ldap-manager)
 [![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/ldap-manager)](https://goreportcard.com/report/github.com/netresearch/ldap-manager)
 [![License: MIT](https://img.shields.io/github/license/netresearch/ldap-manager)](LICENSE)
@@ -165,7 +165,7 @@ Full documentation is available in [`docs/`](docs/):
 
 ## Accessibility
 
-LDAP Manager's login page conforms to [WCAG 2.2](https://www.w3.org/TR/WCAG22/) Level AAA in *comfortable* density (the default on touch devices, narrow viewports, and under `prefers-reduced-motion`). In *compact* density (the default on desktop), the login page meets Level AA; all AAA success criteria are met except 2.5.5 Target Size (Enhanced), which is a deliberate density-preference trade-off.
+LDAP Manager's login page conforms to [WCAG 2.2](https://www.w3.org/TR/WCAG22/) Level AAA in _comfortable_ density (the default on touch devices, narrow viewports, and under `prefers-reduced-motion`). In _compact_ density (the default on desktop), the login page meets Level AA; all AAA success criteria are met except 2.5.5 Target Size (Enhanced), which is a deliberate density-preference trade-off.
 
 Conformance is enforced in CI by a contrast unit test (`internal/web/contrast_test.go`) and an axe-core AAA pass on every E2E run (`internal/e2e/axe_test.go`). Additional routes will be brought under the same guarantee as they migrate in subsequent slices.
 


### PR DESCRIPTION
## Summary

- **Release pipeline:** Switch `release.yml` to the `release-go-app.yml` atomic-release orchestrator. The old pipeline created an immutable GitHub Release before the binaries job could attach assets, causing **v1.3.0 + v1.4.0 to ship empty** (HTTP 422 *"Cannot upload assets to an immutable release"*) — no binaries on the release, no `:v1.3.0` / `:v1.4.0` container image. Atomic publish at the end fixes this; [v1.4.1-rc2 already validated](https://github.com/netresearch/ldap-manager/actions/runs/24954411288) the orchestrator end-to-end.
- **README badges:** Repair broken **CI** + **Container** badges. Workflow files were renamed (`quality.yml` → `ci.yml`, `docker.yml` → `container.yml`) without touching the README — both badges currently 404.
- **CHANGELOG:** Backfill missing v1.3.0 + v1.4.0 sections (UI revamp Phases 1-3, Phase 3 graph view, Table view) and add v1.4.1.

## v1.4.0 container image (separate)

Out-of-band: `gh workflow run container.yml --ref v1.4.0` was dispatched ([run 24991425245](https://github.com/netresearch/ldap-manager/actions/runs/24991425245)) to publish `ghcr.io/netresearch/ldap-manager:v1.4.0` from the existing tag, since re-triggering the immutable release itself is not possible. v1.3.0 cannot use the same trick (no `container.yml` at that ref).

## Test plan

- [ ] CI green (lint + test + container build for `:main` from this branch).
- [ ] Merge → tag `v1.4.1` (signed annotated) → push → release.yml runs the atomic orchestrator → release published with binaries + `:v1.4.1` image.
- [ ] Verify `gh release view v1.4.1 --json assets,isImmutable` shows assets attached and `isImmutable: true`.
- [ ] Verify `ghcr.io/netresearch/ldap-manager:v1.4.1` resolves and runs.
- [ ] Verify badges render on the README on `main`.