### PR TITLE
ci: pin templ CLI to go.mod runtime version

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -49,3 +49,17 @@ intentional-drift:
     `go install github.com/a-h/templ/cmd/templ@latest && templ generate`
     to the pre-build-command so release binaries compile, mirroring
     ci.yml's existing `pre-build-cmd`."
+- path: .github/workflows/codeql.yml
+  reason: "Same templ-extraction problem as the other workflows.
+    Without `templ generate`, CodeQL's Go autobuilder fails to extract
+    `internal/web` and `internal/web/templates` (gitignored
+    *_templ.go), and the standalone `CodeQL` aggregator returns
+    NEUTRAL — which the `code_scanning` ruleset treats as
+    \"still expecting result\" and blocks merges on every PR,
+    including ones that don't touch any Go (see #597). Passes
+    `pre-build-cmd-go` (introduced in netresearch/.github#119) to
+    install the templ CLI at the go.mod-pinned version and run
+    `templ generate` between CodeQL init and the analyze/extract
+    pass. Other go-app consumers without templ-style codegen don't
+    need this, hence intentional-drift rather than a template
+    change."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
       # cannot be reached from unit tests. Authored-code coverage is the
       # metric that matters.
       test-flags: "-race -covermode=atomic -coverprofile=coverage.out -coverpkg=github.com/netresearch/ldap-manager/cmd/...,github.com/netresearch/ldap-manager/internal/ldap_cache/...,github.com/netresearch/ldap-manager/internal/options/...,github.com/netresearch/ldap-manager/internal/retry/...,github.com/netresearch/ldap-manager/internal/version/...,github.com/netresearch/ldap-manager/internal/web"
-      pre-build-cmd: "go install github.com/a-h/templ/cmd/templ@latest && templ generate"
+      # Pin the templ CLI to the runtime version in go.mod so the generator
+      # never emits symbols (e.g. templ.ResolveAttributeValue) that the pinned
+      # runtime lacks. Bumping go.mod automatically bumps the CLI in lockstep.
+      pre-build-cmd: "go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{.Version}}' github.com/a-h/templ) && templ generate"
       # This PR adds a substantial templ + htmx UI layer to internal/web
       # whose handlers reach live LDAP and are exercised primarily by
       # internal/web/ldap_integration_test.go (skipped without an LDAP

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,14 @@ jobs:
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     with:
       languages: auto
+      # *_templ.go is gitignored, so the autobuilder fails to extract
+      # internal/web and internal/web/templates without this — the
+      # standalone CodeQL aggregator then returns NEUTRAL and the
+      # `code_scanning` ruleset blocks merges. CLI version is
+      # resolved from go.mod (same pattern as ci.yml).
+      pre-build-cmd-go: |
+        go install github.com/a-h/templ/cmd/templ@"$(go list -m -f '{{.Version}}' github.com/a-h/templ)"
+        templ generate
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,10 @@ jobs:
       # resolved from go.mod (same pattern as ci.yml).
       pre-build-cmd-go: |
         go install github.com/a-h/templ/cmd/templ@"$(go list -m -f '{{.Version}}' github.com/a-h/templ)"
+        # `go install` drops binaries into $(go env GOPATH)/bin, which
+        # is not on PATH for the bash shell the reusable codeql.yml
+        # spawns. Same workaround as container.yml.
+        export PATH="$(go env GOPATH)/bin:${PATH}"
         templ generate
     permissions:
       contents: read

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,6 +21,7 @@ name: Container (main)
 on:
   push:
     branches: [main]
+  merge_group: {}
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -64,7 +64,10 @@ jobs:
         set -euo pipefail
 
         echo "::group::install templ + generate"
-        go install github.com/a-h/templ/cmd/templ@latest
+        # Pin the templ CLI to the runtime version in go.mod so the
+        # generator never emits symbols the pinned runtime lacks (see
+        # ci.yml for the full rationale).
+        go install github.com/a-h/templ/cmd/templ@"$(go list -m -f '{{.Version}}' github.com/a-h/templ)"
         # `go install` drops binaries into $(go env GOPATH)/bin, which is
         # not on PATH for the ad-hoc bash shell the reusable
         # build-container.yml spawns for pre-build-command. Add it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,10 @@ jobs:
           bun install --frozen-lockfile
           bun run build:assets
         fi
-        go install github.com/a-h/templ/cmd/templ@latest
+        # Pin the templ CLI to the runtime version in go.mod so the
+        # generator never emits symbols the pinned runtime lacks (see
+        # ci.yml for the full rationale).
+        go install github.com/a-h/templ/cmd/templ@"$(go list -m -f '{{.Version}}' github.com/a-h/templ)"
         templ generate
       # gcr.io/distroless/static-debian12:nonroot (Dockerfile runner stage)
       # only publishes linux/{amd64,arm/v7,arm64,ppc64le,s390x}. linux/386

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+5596d727dd76135ade3a115c5e815b77d71f4e1e:docs/operations/deployment.md:generic-api-key:171
+a8fad1e522007972c28bc714485a0ba6786bf8ca:docs/operations/deployment.md:generic-api-key:174

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,7 +3,9 @@ package version
 
 import "fmt"
 
-// Version contains the application version string, set during build time.
+// Version, CommitHash, and BuildTimestamp hold build-time metadata
+// injected via -ldflags at link time. They default to "dev" / "n/a"
+// for local builds.
 var (
 	Version        = "dev"
 	CommitHash     = "n/a"


### PR DESCRIPTION
## Summary

CI runs `go install github.com/a-h/templ/cmd/templ@latest && templ generate` before every build. The runtime library is pinned in `go.mod` (`v0.3.1001`), but the CLI floats. When upstream releases a CLI that emits a new symbol the pinned runtime doesn't have, every PR fails to build until someone notices and bumps both in lockstep.

This happened on 2026-05-10: [templ v0.3.1020](https://github.com/a-h/templ/releases/tag/v0.3.1020) was published at 09:04 UTC and started emitting `templ.ResolveAttributeValue`. The next CI run (PR [#593](https://github.com/netresearch/ldap-manager/pull/593) at 10:18 UTC) failed with `undefined: templ.ResolveAttributeValue` across 5 jobs ([failing run](https://github.com/netresearch/ldap-manager/actions/runs/25626159909)). Re-running main's last green build would fail the same way.

## Fix

Resolve the CLI version from `go.mod` at workflow runtime:

```yaml
pre-build-cmd: "go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{.Version}}' github.com/a-h/templ) && templ generate"
```

`go` is already on PATH in the reusable `go-check.yml` workflow (set up before `pre-build-cmd` runs), and the existing `bash -euo pipefail` wrapper means a failed `go list` aborts the step instead of silently installing `templ@`.

The follow-up bump from `v0.3.1001` → `v0.3.1020` will arrive via Renovate/Dependabot as a normal `go.mod` PR — the CLI follows automatically.

## Test plan

- [ ] CI on this PR passes (proves the shell expansion works end-to-end)
- [ ] PR #593 turns green after rebase onto this fix