### PR TITLE
ci(dependabot): self-manage config, opt-in devcontainers ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,9 @@
+# Self-managed — intentional-drift from netresearch/.github templates/go-app.
+# Core ecosystems (gomod, github-actions, docker) track the go-app template;
+# the devcontainers block is kept here because this repo has a devcontainer the
+# trimmed template no longer declares (see netresearch/.github#166). This file
+# is listed under intentional-drift in .github/template.yaml so the template
+# sync leaves it alone — keep the core blocks in step with the template manually.
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -32,18 +38,6 @@ updates:
     open-pull-requests-limit: 3
     groups:
       docker:
-        patterns: ['*']
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    groups:
-      npm:
         patterns: ['*']
     cooldown:
       default-days: 7

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -63,3 +63,5 @@ intentional-drift:
     pass. Other go-app consumers without templ-style codegen don't
     need this, hence intentional-drift rather than a template
     change."
+- path: .github/dependabot.yml
+  reason: "Opt-in devcontainers ecosystem. The trimmed go-app template (netresearch/.github#166) declares only gomod/github-actions/docker; this repo has a .devcontainer so it self-manages dependabot.yml to keep devcontainers updates. Core blocks are kept in step with the template manually."


### PR DESCRIPTION
Follow-up to netresearch/.github#166, which trimmed the `go-app` template's dependabot.yml to the universally-present ecosystems (gomod, github-actions, docker). This repo has a .devcontainer, so it keeps the `devcontainers` ecosystem by self-managing `.github/dependabot.yml` and listing it under `intentional-drift:` in `.github/template.yaml`.

Also drops the ecosystem this repo has no manifest for (was failing Dependabot with `dependency_file_not_found`). Core blocks (gomod/github-actions/docker) stay in step with the template manually.

## Test plan
- [ ] After merge: `event=dynamic` Dependabot runs go green (no `dependency_file_not_found`).