### PR TITLE
ci(codeql): scan the JavaScript frontend explicitly

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,13 @@ jobs:
   codeql:
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     with:
-      languages: auto
+      # Explicit go + javascript-typescript. This repo has a plain-JS
+      # frontend (internal/web/static/js/v2-*.js) but no package.json, so
+      # the reusable's `auto` detects only go and never scans the JS —
+      # GitHub then keeps expecting a JavaScript CodeQL result the
+      # code_scanning gate never receives, blocking every PR. Listing JS
+      # explicitly produces that result and closes a real coverage gap.
+      languages: go,javascript-typescript
       # *_templ.go is gitignored, so the autobuilder fails to extract
       # internal/web and internal/web/templates without this — the
       # standalone CodeQL aggregator then returns NEUTRAL and the


### PR DESCRIPTION
## Root cause
The `code_scanning` ruleset blocked *every* ldap-manager PR for weeks (it's why #621 needed the gate removed to merge). Investigation showed why: this repo has a plain-JS frontend (`internal/web/static/js/v2-*.js`, ~59KB) but **no `package.json`**, so the reusable's `languages: auto` detects **go only**. GitHub sees the JS content and keeps **expecting a JavaScript CodeQL result** the go-only workflow never produces → `Code scanning is still expecting 1 result from CodeQL` → merge blocked. (raybeam, pure Go, was never affected.)

## Fix
List `go,javascript-typescript` explicitly so CodeQL actually scans the JS. This also closes a real coverage gap — the frontend JS was never security-scanned. The `pre-build-cmd-go` (templ generate) stays; it fixes the Go autobuilder separately.

## Follow-up
The reusable's `auto` detection (netresearch/.github `codeql.yml`) adds JS/TS only when a `package.json`/TS source is present — it misses repos with raw `.js` files. Worth teaching `auto` to detect `.js`/`.ts` source directly.

Once this is on main (producing the JS result), the `code_scanning` rule + merge_queue can be restored to the ruleset.