### PR TITLE
fix(web): validate command-palette navigation target (DOM XSS)

### DIFF
--- a/internal/web/static/js/v2-palette.js
+++ b/internal/web/static/js/v2-palette.js
@@ -309,6 +309,20 @@
   }
 
   function navigateTo(href) {
+    // hrefFor() only ever produces same-origin absolute paths ("/users/…"),
+    // but the value round-trips through the data-href DOM attribute, so
+    // validate before navigating: a tampered attribute must not be able to
+    // inject a javascript:/data: or cross-origin URL. Require a leading "/"
+    // and reject a second "/" or "\" — browsers normalize "/\host" to the
+    // protocol-relative "//host", so both must be blocked.
+    if (
+      typeof href !== "string" ||
+      href.charAt(0) !== "/" ||
+      href.charAt(1) === "/" ||
+      href.charAt(1) === "\\"
+    ) {
+      return;
+    }
     closePalette();
     window.location.href = href;
   }


### PR DESCRIPTION
## What
CodeQL **`js/xss-through-dom` (high)** — surfaced once CodeQL started scanning the JS frontend (#624). The command palette reads `data-href` back from the DOM and assigns it to `window.location.href` without validation (`internal/web/static/js/v2-palette.js`).

`hrefFor()` only ever produces same-origin absolute paths (`/users/…`), so this isn't currently exploitable — but the value round-trips through a DOM attribute, so a tampered `data-href` could carry a `javascript:`/`data:`/protocol-relative URL that executes on navigation.

## Fix
Guard `navigateTo()` to follow **only single-slash same-origin paths** (`href.charAt(0) === '/' && href.charAt(1) !== '/'`) — rejecting `javascript:`, `data:`, `//host`, and absolute URLs. Defence-in-depth; no behavior change for the real `/users/…` hrefs. Plain ES5, matching the file.