### PR TITLE
chore(docs): drop the sunset Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Supports both Active Directory and OpenLDAP with per-user credential binding.
 [![CI](https://github.com/netresearch/ldap-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/ldap-manager/actions/workflows/ci.yml)
 [![Container](https://github.com/netresearch/ldap-manager/actions/workflows/container.yml/badge.svg)](https://github.com/netresearch/ldap-manager/actions/workflows/container.yml)
 [![codecov](https://codecov.io/gh/netresearch/ldap-manager/graph/badge.svg)](https://codecov.io/gh/netresearch/ldap-manager)
-[![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/ldap-manager)](https://goreportcard.com/report/github.com/netresearch/ldap-manager)
 [![License: MIT](https://img.shields.io/github/license/netresearch/ldap-manager)](LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/netresearch/ldap-manager)](go.mod)
 [![Release](https://img.shields.io/github/v/release/netresearch/ldap-manager)](https://github.com/netresearch/ldap-manager/releases/latest)


### PR DESCRIPTION
Go Report Card has been sunset — goreportcard.com now serves a farewell page:

> After more than a decade of serving the ecosystem, Go Report Card has been sunset.

The badge therefore renders against a dead service and its link leads nowhere useful. Removing it.

Only the badge lines are touched; no other README content changes. Linting coverage is unaffected — `golangci-lint` runs in CI and is what the badge was a proxy for anyway.
