### PR TITLE
fix(security): resolve gosec findings and pin Go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/netresearch/ldap-manager
 
-go 1.26.0
+go 1.26
+
+toolchain go1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020

--- a/internal/ldap_cache/cachetest/helpers.go
+++ b/internal/ldap_cache/cachetest/helpers.go
@@ -55,9 +55,16 @@ func Seed(m *ldap_cache.Manager, users []ldap.User, groups []ldap.Group, compute
 func setObjectFields(obj reflect.Value, dn, cn string) {
 	dnField := obj.FieldByName("dn")
 	cnField := obj.FieldByName("cn")
-	// test-only writers for unexported simple-ldap-go fields; never used in production code.
-	dnPtr := unsafe.Pointer(dnField.UnsafeAddr()) //nolint:gosec // test-only DN field write
-	cnPtr := unsafe.Pointer(cnField.UnsafeAddr()) //nolint:gosec // test-only CN field write
+	// Test-only writers for unexported simple-ldap-go fields. This package is
+	// imported by the tests of two other packages (internal/web and
+	// internal/ldap_cache), and Go cannot share helpers declared in _test.go
+	// files across package boundaries — so it has to be an ordinary package and
+	// is compiled into the binary, unreachable from any production call path.
+	// The unsafe write exists because simple-ldap-go sets Object.dn/cn only in
+	// objectFromEntry when decoding a directory response and exposes no
+	// constructor taking them; see netresearch/simple-ldap-go#191.
+	dnPtr := unsafe.Pointer(dnField.UnsafeAddr()) // #nosec G103 -- test fixture writer, see comment above
+	cnPtr := unsafe.Pointer(cnField.UnsafeAddr()) // #nosec G103 -- test fixture writer, see comment above
 	reflect.NewAt(dnField.Type(), dnPtr).Elem().SetString(dn)
 	reflect.NewAt(cnField.Type(), cnPtr).Elem().SetString(cn)
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -127,7 +127,7 @@ func addJitter(duration time.Duration, fraction float64) time.Duration {
 		return duration
 	}
 
-	jitter := float64(duration) * fraction * rand.Float64() //nolint:gosec // Weak random acceptable for jitter
+	jitter := float64(duration) * fraction * rand.Float64() // #nosec G404 -- backoff jitter only, never a token/nonce/session ID
 
 	return duration + time.Duration(jitter)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -142,11 +142,15 @@ func NewApp(opts *options.Opts) (*App, error) {
 	// Build LDAP client options
 	ldapOpts := []ldap.Option{ldap.WithLogger(logger)}
 
-	// Add TLS skip verify option if configured (for development with self-signed certs)
+	// Add TLS skip verify option if configured (for development with self-signed certs).
+	//
+	// TLSSkipVerify defaults to false and is only ever set by the operator through
+	// LDAP_TLS_SKIP_VERIFY / --tls-skip-verify (see internal/options/app.go). It is not
+	// derived from request data, and enabling it emits a startup warning.
 	if opts.TLSSkipVerify {
 		logger.Warn("TLS certificate verification is disabled - use only for development!")
 		ldapOpts = append(ldapOpts, ldap.WithTLS(&tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // Intentional for development
+			InsecureSkipVerify: true, // #nosec G402 -- opt-in via LDAP_TLS_SKIP_VERIFY, default false (see comment above)
 		}))
 	}
 


### PR DESCRIPTION
gosec became blocking in the shared workflow ([netresearch/.github#312](https://github.com/netresearch/.github/pull/312)) and flagged six findings here; govulncheck failed on four stdlib advisories. **None of the gosec findings turned out to be a real defect** — so each one carries a reason a reviewer can check, not a bare suppression.

| Rule | Where | Verdict |
|---|---|---|
| G402 TLS verification disabled | `internal/web/server.go` | opt-in, not a shipped bypass |
| G704 SSRF | `cmd/ldap-manager/main.go` ×2 | URL is operator config, not request data |
| G404 weak randomness | `internal/retry/retry.go` | backoff jitter only |
| G103 unsafe | `internal/ldap_cache/cachetest/helpers.go` ×2 | test fixture writer |

**G402 is the one worth stating plainly:** `TLSSkipVerify` is a plain `bool` that only `LDAP_TLS_SKIP_VERIFY` / `--tls-skip-verify` sets. Its zero value is `false`, [a test pins that default](https://github.com/netresearch/ldap-manager/blob/main/internal/options/parse_test.go), and enabling it logs a warning at startup. Verification is not disabled unless an operator asks for it.

**G404**: `rand.Float64` supplies jitter in `addJitter`. It produces no token, nonce or session ID — `crypto/rand` would buy nothing.

**G103**: the helpers write simple-ldap-go's unexported `Object.dn`/`cn` through reflection when building test fixtures. That library sets those fields only in `objectFromEntry` and exposes no constructor taking them, so a fixture cannot be built through its public API — filed as [simple-ldap-go#191](https://github.com/netresearch/simple-ldap-go/issues/191).

An earlier revision of this PR moved the scaffolding into a `_test.go` file, the way [raybeam#254](https://github.com/netresearch/raybeam/pull/254) did, which removes `unsafe` from the binary entirely. That does not work here: the tests of both `internal/web` and `internal/ldap_cache` import these helpers, and Go does not share `_test.go` declarations across package boundaries. Duplicating them into each package cleared gosec but tripped SonarCloud's duplication gate at 20.8% — correctly, since it was duplication. So the shared package stays, and its comment now explains why it is an ordinary package instead of asserting "test-only". It is compiled in, reachable from no production path.

## govulncheck

GO-2026-5856 (crypto/tls), GO-2026-5039 (net/textproto), GO-2026-5037 (crypto/x509), GO-2026-4971 (net). The module moves to `go 1.26` with `toolchain go1.26.5`, matching ofelia.

## Verification

- gosec: `Issues : 0`, exit 0
- govulncheck: 0 affecting vulnerabilities, exit 0
- `go build`, `go vet`, `go test ./...` all pass
