### PR TITLE
ci(mutation): generate templ sources before gremlins runs

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -63,5 +63,17 @@ intentional-drift:
     pass. Other go-app consumers without templ-style codegen don't
     need this, hence intentional-drift rather than a template
     change."
+- path: .github/workflows/mutation.yml
+  reason: "Same templ-extraction problem as ci.yml, release.yml, codeql.yml and
+    container.yml — and the one workflow that never got the treatment. gremlins
+    compiles the packages it mutates, so without `templ generate` it cannot
+    build internal/web/templates, internal/web or cmd/ldap-manager. It reports
+    them as `[build failed]`, drops them from the run, and publishes a score
+    computed over the rest while the job stays green: the mutation score never
+    covered the handler, auth and routing layer. Passes `pre-build-cmd`
+    (introduced in netresearch/.github#314, which also makes `[build failed]`
+    fail the job) with the same go.mod-pinned templ CLI invocation ci.yml uses.
+    Other go-app consumers without templ-style codegen don't need this, hence
+    intentional-drift rather than a template change."
 - path: .github/dependabot.yml
   reason: "Opt-in devcontainers ecosystem. The trimmed go-app template (netresearch/.github#166) declares only gomod/github-actions/docker; this repo has a .devcontainer so it self-manages dependabot.yml to keep devcontainers updates. Core blocks are kept in step with the template manually."

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -21,6 +21,13 @@ jobs:
     uses: netresearch/.github/.github/workflows/go-mutation-testing.yml@main
     with:
       diff-only: ${{ github.event_name == 'pull_request' }}
+      # The *_templ.go sources are generated and not committed, so gremlins
+      # cannot compile internal/web/templates — nor internal/web and
+      # cmd/ldap-manager, which depend on it — without generating them first.
+      # Same command and CLI pinning as ci.yml: the templ CLI is tied to the
+      # runtime version in go.mod so the generator never emits symbols the
+      # pinned runtime lacks.
+      pre-build-cmd: "go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{.Version}}' github.com/a-h/templ) && templ generate"
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Caller side of [netresearch/.github#314](https://github.com/netresearch/.github/pull/314).

The `*_templ.go` sources are produced by the templ CLI and are not committed, so gremlins could not compile `internal/web/templates` — nor `internal/web` and `cmd/ldap-manager`, which depend on it:

```
internal/web/templates/palette_helpers.go:9:26: undefined: PinnedEntry
FAIL github.com/netresearch/ldap-manager/cmd/ldap-manager       [build failed]
FAIL github.com/netresearch/ldap-manager/internal/web           [build failed]
FAIL github.com/netresearch/ldap-manager/internal/web/templates [build failed]
```

All three were dropped from every run and the score was computed over the rest of the tree, while the job stayed green and the failure appeared only as an annotation on a passing check. `internal/web` is the handler, auth and routing layer — the number never covered the part of the codebase it most needed to.

This passes `pre-build-cmd`, the input [#314](https://github.com/netresearch/.github/pull/314) added, using the same command and CLI pinning `ci.yml` already uses: the templ CLI is tied to the runtime version in `go.mod` so the generator cannot emit symbols the pinned runtime lacks.

**Expect the reported mutation score to move** — it now covers three packages it never did, and `internal/web` is large. Whatever it lands at is the first honest number for this repo. The 60% threshold is advisory and does not fail the job.

[#314](https://github.com/netresearch/.github/pull/314) also makes `[build failed]` fail the job, so a future gap of this kind is loud rather than silent. If this PR's own mutation run goes red on a build error, that check is doing its job and the cause is worth reading rather than working around.
