### PR TITLE
docs(changelog): cut v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v1.5.1] - 2026-07-28
+
+### Security
+
+- **Go toolchain moves to 1.26.5** — module `go 1.26`, `toolchain go1.26.5` ([#630](https://github.com/netresearch/ldap-manager/pull/630)). Clears the 14 standard-library advisories govulncheck reported as affecting the binary, among them GO-2026-5856 (`crypto/tls`), GO-2026-5039 (`net/textproto`), GO-2026-5037 (`crypto/x509`) and GO-2026-4971 (`net`).
+
+### Changed
+
+- **gosec is a blocking check** ([#630](https://github.com/netresearch/ldap-manager/pull/630), [netresearch/.github#312](https://github.com/netresearch/.github/pull/312)). It flagged four sites here; **none was a defect**. The `//nolint:gosec` comments they carried — which only golangci-lint reads — became `#nosec` annotations stating a reason gosec itself records. No code behaviour changed.
+  - G402 (TLS verification disabled): `TLSSkipVerify` is a plain bool, default `false`, set only by an operator through `LDAP_TLS_SKIP_VERIFY` / `--tls-skip-verify`, and enabling it logs a startup warning. It is never derived from request data.
+  - G404 (weak randomness): `math/rand/v2` supplies backoff jitter in `internal/retry` — no token, nonce or session ID.
+  - G103 (unsafe) ×2: the test-fixture helpers in `internal/ldap_cache/cachetest` write simple-ldap-go's unexported `Object.dn`/`cn` through reflection, because that library exposed no constructor taking them ([simple-ldap-go#191](https://github.com/netresearch/simple-ldap-go/issues/191)). It now has `NewObject`; the `unsafe` goes once a release carrying it is picked up here.
+- **Mutation testing covers the whole tree** ([#631](https://github.com/netresearch/ldap-manager/pull/631)). The `*_templ.go` sources are generated and not committed, so gremlins could not compile `internal/web/templates` — nor `internal/web` and `cmd/ldap-manager`, which depend on it. It reported the three as `[build failed]`, then aborted before gathering coverage, and the job stayed green publishing a score of 0%; `internal/web` is the handler, auth and routing layer. The run now generates templ sources first via `pre-build-cmd` ([netresearch/.github#314](https://github.com/netresearch/.github/pull/314)), which also makes `[build failed]` fail the job. First score over the full tree: **57.07%**.
+
+### Removed
+
+- Go Report Card badge ([#629](https://github.com/netresearch/ldap-manager/pull/629)) — the service is sunset.
+
+### Dependencies
+
+- `github.com/gofiber/storage/bbolt/v2` v2.1.8 → v2.1.9 ([#628](https://github.com/netresearch/ldap-manager/pull/628)).
+
+---
+
 ## [v1.5.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Go toolchain moves to 1.26.5** — module `go 1.26`, `toolchain go1.26.5` ([#630](https://github.com/netresearch/ldap-manager/pull/630)). Clears the 14 standard-library advisories govulncheck reported as affecting the binary, among them GO-2026-5856 (`crypto/tls`), GO-2026-5039 (`net/textproto`), GO-2026-5037 (`crypto/x509`) and GO-2026-4971 (`net`).
+- **Go toolchain moves to 1.26.5** — module `go 1.26`, `toolchain go1.26.5` ([#630](https://github.com/netresearch/ldap-manager/pull/630)). Clears the standard-library advisories govulncheck reported as affecting the binary — the exact count depends on the patch release compared against, so they are named rather than counted: GO-2026-5856 (`crypto/tls`), GO-2026-5039 (`net/textproto`), GO-2026-5037 (`crypto/x509`) and GO-2026-4971 (`net`).
 
 ### Changed
 


### PR DESCRIPTION
Records what landed since [v1.5.0](https://github.com/netresearch/ldap-manager/releases/tag/v1.5.0) and dates it as v1.5.1. `[Unreleased]` was empty — none of this had been written down. No user-facing change in this release; it is CI, toolchain and annotation work. The tag follows once this merges.

Two things differ from how the work was described in passing, both verified against the tree and the CI logs:

**gosec flagged four sites, not six.** Running gosec over the v1.5.0 tree (after `templ generate`) reports exactly `G404 internal/retry/retry.go:130`, `G402 internal/web/server.go:149` and `G103 internal/ldap_cache/cachetest/helpers.go:59,60` — `found: 4`, and 0 on this branch. The two G704 SSRF findings in `cmd/ldap-manager/main.go` were suppressed back in [262fd57](https://github.com/netresearch/ldap-manager/commit/262fd579f19446dce34cc78200d95d00f0daa3ac) (shipped in v1.3.0) and were untouched here; `git diff v1.5.0..HEAD` does not contain `main.go`. That also makes their description worth correcting for the record: the URL there is not the LDAP server address but the Docker healthcheck target `http://localhost:$PORT/health/live`, built from `PORT` with a numeric-range check in `isValidPort` before the request. The changelog therefore lists G402, G404 and G103 ×2 only.

**The mutation score published before #631 was 0%, not a higher partial number.** gremlins did not compute a score over the surviving packages — it aborted: `ERROR: failed to gather coverage: impossible to executeCoverage coverage: exit status 1` in every run back to at least 2026-06-28, so no `Test efficacy:` line was ever emitted and the reporter's fallback published `**Mutation Score:** 0% (threshold: 60%)` (see the bot comment on [#626](https://github.com/netresearch/ldap-manager/pull/626)) while the job stayed green. 57.07% is therefore not a corrected-downward number, it is the first number at all. The rest of that account holds: the three packages were dropped as `[build failed]`, `internal/web` is the handler/auth/routing layer, and `pre-build-cmd` from [netresearch/.github#314](https://github.com/netresearch/.github/pull/314) fixes it and makes `[build failed]` fail the job.

One addition: govulncheck reported **14** affecting standard-library advisories on `ba604b6`, not four — `Your code is affected by 14 vulnerabilities from the Go standard library` in [run 30385910538](https://github.com/netresearch/ldap-manager/actions/runs/30385910538). The four named in #630 are a subset. The entry names those four and gives the full count.

Everything else checked out: `TLSSkipVerify` is a plain bool defaulting to false, set only via `LDAP_TLS_SKIP_VERIFY` / `--tls-skip-verify` (`internal/options/app.go:51,179,256,322`) with the default pinned by `internal/options/parse_test.go:176`; `internal/retry` uses `math/rand/v2` for jitter only; [simple-ldap-go#191](https://github.com/netresearch/simple-ldap-go/issues/191) is closed by [#193](https://github.com/netresearch/simple-ldap-go/pull/193) adding `NewObject`, which is not yet in a release (latest is v1.13.0, 2026-07-23), so the `unsafe` stays for now.
