### PR TITLE
ci: add zizmor config exempting first-party reusables

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,21 @@
+name: Zizmor
+
+# Static analysis of the repo's GitHub Actions workflows (https://zizmor.sh).
+# Report-only: the reusable runs in SARIF mode (exit 0 regardless of findings)
+# and uploads results to the Security / code-scanning tab, like CodeQL and
+# Scorecard. Findings surface as alerts; they never fail CI.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor (https://zizmor.sh) configuration
+#
+# Tunes zizmor to Netresearch conventions so the audit reports only
+# actionable findings. Third-party actions remain hash-pin enforced.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track @main by policy and are
+        # never SHA-pinned, so fixes propagate to all consumers.
+        "netresearch/*": ref-pin
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin


### PR DESCRIPTION
Adds `.github/zizmor.yml`, byte-identical to the shared template config in
netresearch/.github#329.

zizmor's default `unpinned-uses` policy is blanket hash-pin, so it flags every
`netresearch/*` reusable referenced `@main`. First-party reusables track `@main`
by policy so fixes propagate to all consumers without a SHA bump, so they are
exempted to `ref-pin` here.

Third-party actions remain hash-pin enforced — the audit is not disabled.

This repo is a template consumer (`.github/template.yaml`), and the shared
templates now ship this file, so it is required to keep the template drift check
green.
