### PR TITLE
chore: add CODEOWNERS per estate standard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS - Defines code ownership for pull request reviews
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @CybotTM @netresearch/netresearch
+
+# Security-sensitive files require security team review
+/.github/workflows/ @CybotTM @netresearch/sec
+/SECURITY.md @CybotTM @netresearch/sec


### PR DESCRIPTION
Aligns CODEOWNERS with the estate standard (ofelia's pattern, copied verbatim): default owners `@CybotTM` + `@netresearch/netresearch` (11 members), workflows and SECURITY.md additionally `@netresearch/sec` (6 members). Code-owner review is not an enforced merge gate on this repo — this is reviewer auto-request routing.