### PR TITLE
fix: stop Renovate from managing Go modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "github>netresearch/renovate-config"
   ],
+  "gomod": {
+    "enabled": false
+  },
   "automergeType": "pr",
   "platformAutomerge": true,
   "packageRules": [


### PR DESCRIPTION
Fixes #660. Dependabot (per the go-app template) and Renovate both managed gomod, producing duplicate racing update PRs. Dependabot stays the owner of the core ecosystems; Renovate's gomod manager is disabled via the top-level manager toggle. Actions/docker duplication was not part of the issue and is untouched.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01L7tF9XuJfAfFk4yuY5KfPK)_