### PR TITLE
fix(deps): update netresearch/simple-ldap-go to v1.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gofiber/storage/memory/v2 v2.1.2
 	github.com/joho/godotenv v1.5.1
 	github.com/mxschmitt/playwright-go v0.6201.1
-	github.com/netresearch/simple-ldap-go v1.15.0
+	github.com/netresearch/simple-ldap-go v1.16.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.1
 	github.com/testcontainers/testcontainers-go v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -424,8 +424,8 @@ github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
 github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
-github.com/netresearch/simple-ldap-go v1.15.0 h1:b9gMf2DfbmA8wxzivngPkNGYs3m/5BqWjfhLend0uPc=
-github.com/netresearch/simple-ldap-go v1.15.0/go.mod h1:pqKRqkhCfn3rcMUZk5cG+Fjf3h8Na6GXfmSSbwYl0wQ=
+github.com/netresearch/simple-ldap-go v1.16.0 h1:ol1Z0SNuF8Bh5DKfBAr7fvqw8pJHYNQDt75I75wjO3A=
+github.com/netresearch/simple-ldap-go v1.16.0/go.mod h1:rNNMG/dUI25L1qV/53siryQPRVJtEYKZAwMWivgbtBQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=
 github.com/nishanths/exhaustive v0.12.0/go.mod h1:mEZ95wPIZW+x8kC4TgC+9YCUgiST7ecevsVDTgc2obs=
 github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm/w98Vk=


### PR DESCRIPTION
Part of the release train: brings the #219 DN timing-oracle fix (constant-time dummy bind on `CheckPasswordForDN`). Build, vet, golangci-lint (0 issues) and the race suite (8 packages) green locally under go1.27.0.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01L7tF9XuJfAfFk4yuY5KfPK)_